### PR TITLE
Workaround OOM when training on v4-8

### DIFF
--- a/llama_training_xla/pyproject.toml
+++ b/llama_training_xla/pyproject.toml
@@ -13,8 +13,12 @@ authors = [
     {name = "Jiewen Tan", email = "jwtan@google.com"},
 ]
 dependencies = [
-    "transformers",
-    "datasets",
+    "accelerate==1.2.1",
+    "transformers==4.47.1",
+    "datasets==3.2.0",
+
+    # `transformers` requires `tensorflow` now.
+    "tensorflow==2.15.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
It appears optimizer priming uses up too much HBM. Maybe it forces the optimizer state to be replicated instead of sharded.

The loss is valid at step 1 but becomes NaN later. We'll have to investigate this separately.

Tested: XLA_IR_DEBUG=1 XLA_HLO_DEBUG=1 python trainer.py configs/run.json