### PR TITLE
Lint and format repo

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,393 @@
+[style]
+# Align closing bracket with visual indentation.
+align_closing_bracket_with_visual_indent=False
+
+# Allow dictionary keys to exist on multiple lines. For example:
+#
+#   x = {
+#       ('this is the first element of a tuple',
+#        'this is the second element of a tuple'):
+#            value,
+#   }
+allow_multiline_dictionary_keys=False
+
+# Allow lambdas to be formatted on more than one line.
+allow_multiline_lambdas=False
+
+# Allow splitting before a default / named assignment in an argument list.
+allow_split_before_default_or_named_assigns=False
+
+# Allow splits before the dictionary value.
+allow_split_before_dict_value=True
+
+#   Let spacing indicate operator precedence. For example:
+#
+#     a = 1 * 2 + 3 / 4
+#     b = 1 / 2 - 3 * 4
+#     c = (1 + 2) * (3 - 4)
+#     d = (1 - 2) / (3 + 4)
+#     e = 1 * 2 - 3
+#     f = 1 + 2 + 3 + 4
+#
+# will be formatted as follows to indicate precedence:
+#
+#     a = 1*2 + 3/4
+#     b = 1/2 - 3*4
+#     c = (1+2) * (3-4)
+#     d = (1-2) / (3+4)
+#     e = 1*2 - 3
+#     f = 1 + 2 + 3 + 4
+#
+arithmetic_precedence_indication=False
+
+# Number of blank lines surrounding top-level function and class
+# definitions.
+blank_lines_around_top_level_definition=2
+
+# Insert a blank line before a class-level docstring.
+blank_line_before_class_docstring=False
+
+# Insert a blank line before a module docstring.
+blank_line_before_module_docstring=False
+
+# Insert a blank line before a 'def' or 'class' immediately nested
+# within another 'def' or 'class'. For example:
+#
+#   class Foo:
+#                      # <------ this blank line
+#     def method():
+#       ...
+blank_line_before_nested_class_or_def=True
+
+# Do not split consecutive brackets. Only relevant when
+# dedent_closing_brackets is set. For example:
+#
+#    call_func_that_takes_a_dict(
+#        {
+#            'key1': 'value1',
+#            'key2': 'value2',
+#        }
+#    )
+#
+# would reformat to:
+#
+#    call_func_that_takes_a_dict({
+#        'key1': 'value1',
+#        'key2': 'value2',
+#    })
+coalesce_brackets=False
+
+# The column limit.
+column_limit=80
+
+# The style for continuation alignment. Possible values are:
+#
+# - SPACE: Use spaces for continuation alignment. This is default behavior.
+# - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+#   (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs or
+#   CONTINUATION_INDENT_WIDTH spaces) for continuation alignment.
+# - VALIGN-RIGHT: Vertically align continuation lines to multiple of
+#   INDENT_WIDTH columns. Slightly right (one tab or a few spaces) if
+#   cannot vertically align continuation lines with indent characters.
+continuation_align_style=SPACE
+
+# Indent width used for line continuations.
+continuation_indent_width=4
+
+# Put closing brackets on a separate line, dedented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#   }        # <--- this bracket is dedented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#   )        # <--- this bracket is dedented and on a separate line
+dedent_closing_brackets=False
+
+# Disable the heuristic which places each list element on a separate line
+# if the list is comma-terminated.
+disable_ending_comma_heuristic=False
+
+# Place each dictionary entry onto its own line.
+each_dict_entry_on_separate_line=True
+
+# Require multiline dictionary even if it would normally fit on one line.
+# For example:
+#
+#   config = {
+#       'key1': 'value1'
+#   }
+force_multiline_dict=False
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+i18n_comment=#\..*
+
+# The i18n function call names. The presence of this function stops
+# reformatting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+i18n_function_call=N_, _
+
+# Indent blank lines.
+indent_blank_lines=False
+
+# Put closing brackets on a separate line, indented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#       }        # <--- this bracket is indented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#       )        # <--- this bracket is indented and on a separate line
+indent_closing_brackets=False
+
+# Indent the dictionary value if it cannot fit on the same line as the
+# dictionary key. For example:
+#
+#   config = {
+#       'key1':
+#           'value1',
+#       'key2': value1 +
+#               value2,
+#   }
+indent_dictionary_value=True
+
+# The number of columns to use for indentation.
+indent_width=2
+
+# Join short lines into one line. E.g., single line 'if' statements.
+join_multiple_lines=False
+
+# Do not include spaces around selected binary operators. For example:
+#
+#   1 + 2 * 3 - 4 / 5
+#
+# will be formatted as follows when configured with "*,/":
+#
+#   1 + 2*3 - 4/5
+no_spaces_around_selected_binary_operators=
+
+# Use spaces around default or named assigns.
+spaces_around_default_or_named_assign=False
+
+# Adds a space after the opening '{' and before the ending '}' dict delimiters.
+#
+#   {1: 2}
+#
+# will be formatted as:
+#
+#   { 1: 2 }
+spaces_around_dict_delimiters=False
+
+# Adds a space after the opening '[' and before the ending ']' list delimiters.
+#
+#   [1, 2]
+#
+# will be formatted as:
+#
+#   [ 1, 2 ]
+spaces_around_list_delimiters=False
+
+# Use spaces around the power operator.
+spaces_around_power_operator=False
+
+# Use spaces around the subscript / slice operator.  For example:
+#
+#   my_list[1 : 10 : 2]
+spaces_around_subscript_colon=False
+
+# Adds a space after the opening '(' and before the ending ')' tuple delimiters.
+#
+#   (1, 2, 3)
+#
+# will be formatted as:
+#
+#   ( 1, 2, 3 )
+spaces_around_tuple_delimiters=False
+
+# The number of spaces required before a trailing comment.
+# This can be a single value (representing the number of spaces
+# before each trailing comment) or list of values (representing
+# alignment column values; trailing comments within a block will
+# be aligned to the first column value that is greater than the maximum
+# line length within the block). For example:
+#
+# With spaces_before_comment=5:
+#
+#   1 + 1 # Adding values
+#
+# will be formatted as:
+#
+#   1 + 1     # Adding values <-- 5 spaces between the end of the statement and comment
+#
+# With spaces_before_comment=15, 20:
+#
+#   1 + 1 # Adding values
+#   two + two # More adding
+#
+#   longer_statement # This is a longer statement
+#   short # This is a shorter statement
+#
+#   a_very_long_statement_that_extends_beyond_the_final_column # Comment
+#   short # This is a shorter statement
+#
+# will be formatted as:
+#
+#   1 + 1          # Adding values <-- end of line comments in block aligned to col 15
+#   two + two      # More adding
+#
+#   longer_statement    # This is a longer statement <-- end of line comments in block aligned to col 20
+#   short               # This is a shorter statement
+#
+#   a_very_long_statement_that_extends_beyond_the_final_column  # Comment <-- the end of line comments are aligned based on the line length
+#   short                                                       # This is a shorter statement
+#
+spaces_before_comment=2
+
+# Insert a space between the ending comma and closing bracket of a list,
+# etc.
+space_between_ending_comma_and_closing_bracket=False
+
+# Use spaces inside brackets, braces, and parentheses.  For example:
+#
+#   method_call( 1 )
+#   my_dict[ 3 ][ 1 ][ get_index( *args, **kwargs ) ]
+#   my_set = { 1, 2, 3 }
+space_inside_brackets=False
+
+# Split before arguments
+split_all_comma_separated_values=False
+
+# Split before arguments, but do not split all subexpressions recursively
+# (unless needed).
+split_all_top_level_comma_separated_values=False
+
+# Split before arguments if the argument list is terminated by a
+# comma.
+split_arguments_when_comma_terminated=False
+
+# Set to True to prefer splitting before '+', '-', '*', '/', '//', or '@'
+# rather than after.
+split_before_arithmetic_operator=False
+
+# Set to True to prefer splitting before '&', '|' or '^' rather than
+# after.
+split_before_bitwise_operator=False
+
+# Split before the closing bracket if a list or dict literal doesn't fit on
+# a single line.
+split_before_closing_bracket=True
+
+# Split before a dictionary or set generator (comp_for). For example, note
+# the split before the 'for':
+#
+#   foo = {
+#       variable: 'Hello world, have a nice day!'
+#       for variable in bar if variable != 42
+#   }
+split_before_dict_set_generator=False
+
+# Split before the '.' if we need to split a longer expression:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'.format(a, b, c, d))
+#
+# would reformat to something like:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'
+#          .format(a, b, c, d))
+split_before_dot=False
+
+# Split after the opening paren which surrounds an expression if it doesn't
+# fit on a single line.
+split_before_expression_after_opening_paren=True
+
+# If an argument / parameter list is going to be split, then split before
+# the first argument.
+split_before_first_argument=False
+
+# Set to True to prefer splitting before 'and' or 'or' rather than
+# after.
+split_before_logical_operator=False
+
+# Split named assignments onto individual lines.
+split_before_named_assigns=True
+
+# Set to True to split list comprehensions and generators that have
+# non-trivial expressions and multiple clauses before each of these
+# clauses. For example:
+#
+#   result = [
+#       a_long_var + 100 for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+#
+# would reformat to something like:
+#
+#   result = [
+#       a_long_var + 100
+#       for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+split_complex_comprehension=True
+
+# The penalty for splitting right after the opening bracket.
+split_penalty_after_opening_bracket=300
+
+# The penalty for splitting the line after a unary operator.
+split_penalty_after_unary_operator=10000
+
+# The penalty of splitting the line around the '+', '-', '*', '/', '//',
+# ``%``, and '@' operators.
+split_penalty_arithmetic_operator=300
+
+# The penalty for splitting right before an if expression.
+split_penalty_before_if_expr=0
+
+# The penalty of splitting the line around the '&', '|', and '^'
+# operators.
+split_penalty_bitwise_operator=300
+
+# The penalty for splitting a list comprehension or generator
+# expression.
+split_penalty_comprehension=2100
+
+# The penalty for characters over the column limit.
+split_penalty_excess_character=7000
+
+# The penalty incurred by adding a line split to the unwrapped line. The
+# more line splits added the higher the penalty.
+split_penalty_for_added_line_split=30
+
+# The penalty of splitting a list of "import as" names. For example:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+#                                                             long_argument_2,
+#                                                             long_argument_3)
+#
+# would reformat to something like:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (
+#       long_argument_1, long_argument_2, long_argument_3)
+split_penalty_import_names=0
+
+# The penalty of splitting the line around the 'and' and 'or'
+# operators.
+split_penalty_logical_operator=300
+
+# Use the Tab character for indentation.
+use_tabs=False

--- a/README.md
+++ b/README.md
@@ -62,6 +62,31 @@ version is not expected to be run.
 
 Contributions are welcome! Please feel free to submit a pull request.
 
+When developing, use `pip install -e '.[dev]'` to install dev dependencies such
+as linter and formatter.
+
+How to run tests:
+
+```sh
+pytest
+```
+
+How to format:
+
+```sh
+yapf --recursive -i '*.py' torchprime launcher
+```
+
+The VSCode yapf plugin should be able to pickup the `.style.yapf` file just fine.
+
+How to lint:
+
+```sh
+ruff check [--fix]
+```
+
+You can install a Ruff VSCode plugin to check errors in the editor.
+
 ## License
 
 This project is licensed under the New BSD License - see the [LICENSE](LICENSE)

--- a/launcher/run_xpk.py
+++ b/launcher/run_xpk.py
@@ -1,13 +1,13 @@
-from datetime import datetime
 import os
-import sys
 import subprocess
+import sys
+from datetime import datetime
 
 # Some passes in XLA can only dump to regular folders. Hence,
 # mount the GCS bucket at gs://hanq-llama at `/tmp/gcs-mount` using gcsfuse.
-gcs_mount = '/tmp/gcs-mount'
+gcs_mount = "/tmp/gcs-mount"
 os.makedirs(gcs_mount, exist_ok=True)
-subprocess.run(['gcsfuse', 'hanq-llama', gcs_mount], check=True)
+subprocess.run(["gcsfuse", "hanq-llama", gcs_mount], check=True)
 
 # These are set by GKE automatically.
 worker_id = os.getenv("TPU_WORKER_ID", "0")
@@ -16,14 +16,16 @@ slice_id = os.getenv("MEGASCALE_SLICE_ID", "0")
 # Configure XLA graph dump path before doing anything else.
 date_string = datetime.now().strftime("%Y%m%d-%H%M")
 jobset_name = os.getenv("JOBSET_NAME", date_string)
-xla_dump_path = f'{gcs_mount}/llama3-{slice_id}-{worker_id}/xla_dumps/{jobset_name}/'
-os.environ['XLA_FLAGS'] = os.getenv('XLA_FLAGS', '') + f' --xla_dump_to={xla_dump_path}'
+xla_dump_path = (
+    f"{gcs_mount}/llama3-{slice_id}-{worker_id}/xla_dumps/{jobset_name}/")
+os.environ["XLA_FLAGS"] = (
+    os.getenv("XLA_FLAGS", "") + f" --xla_dump_to={xla_dump_path}")
 print(f"Dumping XLA compiler outputs to {xla_dump_path}")
 
 # Determine the profile dir
-profile_dir = f'{gcs_mount}/llama3-{slice_id}-{worker_id}/'
+profile_dir = f"{gcs_mount}/llama3-{slice_id}-{worker_id}/"
 
 # Exec into the training script.
-args = [sys.executable] + sys.argv[1:] + ['--profile_dir', profile_dir]
+args = [sys.executable] + sys.argv[1:] + ["--profile_dir", profile_dir]
 env = os.environ.copy()
 os.execve(sys.executable, args, env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,13 @@ dependencies = [
     "tf_keras==2.18.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "ruff~=0.8.6",
+    "pytest~=8.3.4",
+    "yapf~=0.43.0"
+]
+
 [tool.setuptools.packages.find]
 where = [""]
 include = ["torchprime*"]
@@ -31,3 +38,27 @@ exclude = ["torchprime.*.tests.*"]
 
 [tool.setuptools.package-data]
 "torchprime" = ["py.typed"]
+
+[tool.ruff]
+indent-width = 4
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+ignore = [
+    "E501",  # Line too long. Some copied GPU code has lengthy comments.
+]
+

--- a/torchprime/data/__init__.py
+++ b/torchprime/data/__init__.py
@@ -1,4 +1,3 @@
 """
 The data module contains datasets and efficient dataloading implementations.
 """
-

--- a/torchprime/experimental/torchax_models/custom_mesh.py
+++ b/torchprime/experimental/torchax_models/custom_mesh.py
@@ -1,14 +1,9 @@
+import collections
+from collections.abc import Sequence
+from typing import Any
+
 import numpy as np
 from jax.experimental import mesh_utils
-import functools
-import time
-import optax
-import os
-import socket
-import subprocess
-from collections.abc import Sequence
-import collections
-from typing import Any, Tuple
 
 
 def create_custom_64x4_device_mesh(
@@ -19,25 +14,27 @@ def create_custom_64x4_device_mesh(
     should_sort_granules_by_key: bool = True,
 ) -> np.ndarray:
   """Custom device mesh for 64x4 ici parallelism"""
-  assert len(devices) % 256 == 0, f"This custom mesh is not valid for {len(devices)} devices"
+  assert (len(devices) %
+          256 == 0), f"This custom mesh is not valid for {len(devices)} devices"
   attr = "process_index" if process_is_granule else "slice_index"
   if not hasattr(devices[0], attr):
-    raise ValueError(f"Device {devices[0]} does not have attribute {attr}. See" " `process_is_granule` option.")
+    raise ValueError(f"Device {devices[0]} does not have attribute {attr}. See"
+                     " `process_is_granule` option.")
   granule_dict = collections.defaultdict(list)
   for dev in devices:
     granule_dict[getattr(dev, attr)].append(dev)
-  granules = (
-      [granule_dict[key] for key in sorted(granule_dict.keys())] if should_sort_granules_by_key else granule_dict.values()
-  )
+  granules = ([granule_dict[key] for key in sorted(granule_dict.keys())]
+              if should_sort_granules_by_key else granule_dict.values())
   if np.prod(dcn_mesh_shape) != len(granules):
-    raise ValueError(f"Number of slices {len(granules)} must equal the product of " f"dcn_mesh_shape {dcn_mesh_shape}")
+    raise ValueError(
+        f"Number of slices {len(granules)} must equal the product of "
+        f"dcn_mesh_shape {dcn_mesh_shape}")
   per_granule_meshes = [
       mesh_utils.create_device_mesh(
           [16, 16],
           granule,
           allow_split_physical_axes=False,
-      )
-      for granule in granules
+      ) for granule in granules
   ]
 
   def reshape_mesh_to_rings(a):
@@ -48,14 +45,24 @@ def create_custom_64x4_device_mesh(
         a_i = i * 2
         a_j = j * 2
         # forms a ring of size 4
-        b[i].append([a[a_i, a_j], a[a_i, a_j + 1], a[a_i + 1, a_j + 1], a[a_i + 1, a_j]])
+        b[i].append([
+            a[a_i, a_j],
+            a[a_i, a_j + 1],
+            a[a_i + 1, a_j + 1],
+            a[a_i + 1, a_j],
+        ])
     b = np.array(b)
     b = np.reshape(b, (64, 4))
     return b
 
-  per_granule_meshes = [np.reshape(reshape_mesh_to_rings(x), mesh_shape) for x in per_granule_meshes]
+  per_granule_meshes = [
+      np.reshape(reshape_mesh_to_rings(x), mesh_shape)
+      for x in per_granule_meshes
+  ]
   # TODO(jekbradbury): handle non-uniform DCN topologies
   granule_mesh = np.arange(len(granules)).reshape(dcn_mesh_shape)
-  blocks = np.vectorize(lambda i: per_granule_meshes[i], otypes=[object])(granule_mesh)
+  blocks = np.vectorize(
+      lambda i: per_granule_meshes[i], otypes=[object])(
+          granule_mesh)
   device_mesh = np.block(blocks.tolist())
   return device_mesh

--- a/torchprime/experimental/torchax_models/llama/model.py
+++ b/torchprime/experimental/torchax_models/llama/model.py
@@ -11,45 +11,48 @@
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/model.py
 
 import math
-from typing import Optional, Tuple
+from dataclasses import dataclass
 
 import torch
 import torch.nn.functional as F
 from torch import nn
-from dataclasses import dataclass
+
 
 @dataclass
 class ModelArgs:
-    dim: int = 4096
-    n_layers: int = 32
-    n_heads: int = 32
-    n_kv_heads: Optional[int] = None
-    vocab_size: int = -1
-    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
-    ffn_dim_multiplier: Optional[float] = None
-    norm_eps: float = 1e-5
-    rope_theta: float = 500000
-    use_scaled_rope: bool = False
+  dim: int = 4096
+  n_layers: int = 32
+  n_heads: int = 32
+  n_kv_heads: int | None = None
+  vocab_size: int = -1
+  multiple_of: int = (
+      256  # make SwiGLU hidden layer size multiple of large power of 2
+  )
+  ffn_dim_multiplier: float | None = None
+  norm_eps: float = 1e-5
+  rope_theta: float = 500000
+  use_scaled_rope: bool = False
 
-    max_batch_size: int = 32
-    max_seq_len: int = 8192
-    tp_size: int = 1
+  max_batch_size: int = 32
+  max_seq_len: int = 8192
+  tp_size: int = 1
 
-    # vision model params
-    vision_chunk_size: int = -1  # image resolution for image models
-    vision_max_num_chunks: int = 4
-    vision_num_cross_attention_layers: int = -1
+  # vision model params
+  vision_chunk_size: int = -1  # image resolution for image models
+  vision_max_num_chunks: int = 4
+  vision_num_cross_attention_layers: int = -1
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            if hasattr(self, k):
-                setattr(self, k, v)
+  def __init__(self, **kwargs):
+    for k, v in kwargs.items():
+      if hasattr(self, k):
+        setattr(self, k, v)
 
-        if self.n_kv_heads is None:
-            self.n_kv_heads = self.n_heads
-        assert self.n_kv_heads <= self.n_heads
-        assert self.n_heads % self.n_kv_heads == 0
-        assert self.dim % self.n_heads == 0
+    if self.n_kv_heads is None:
+      self.n_kv_heads = self.n_heads
+    assert self.n_kv_heads <= self.n_heads
+    assert self.n_heads % self.n_kv_heads == 0
+    assert self.dim % self.n_heads == 0
+
 
 # **NOTE**: This code is not runnable without installing `torch` and `fairscale`
 # dependencies. These dependencies are not part of the default dependencies
@@ -66,7 +69,7 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
+        "vocab_size": 128256,
     },
     "70B": {
         "dim": 8192,
@@ -78,7 +81,7 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
+        "vocab_size": 128256,
     },
     "405B": {
         "dim": 16384,
@@ -90,251 +93,261 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
-    }
+        "vocab_size": 128256,
+    },
 }
 
 
 class RMSNorm(torch.nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
 
-    def _norm(self, x):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+  def __init__(self, dim: int, eps: float = 1e-6):
+    super().__init__()
+    self.eps = eps
+    self.weight = nn.Parameter(torch.ones(dim))
 
-    def forward(self, x):
-        output = self._norm(x.float()).type_as(x)
-        return output * self.weight
+  def _norm(self, x):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+  def forward(self, x):
+    output = self._norm(x.float()).type_as(x)
+    return output * self.weight
 
 
 def apply_scaling(freqs: torch.Tensor):
-    # Values obtained from grid search
-    scale_factor = 8
-    low_freq_factor = 1
-    high_freq_factor = 4
-    old_context_len = 8192  # original llama3 length
+  # Values obtained from grid search
+  scale_factor = 8
+  low_freq_factor = 1
+  high_freq_factor = 4
+  old_context_len = 8192  # original llama3 length
 
-    low_freq_wavelen = old_context_len / low_freq_factor
-    high_freq_wavelen = old_context_len / high_freq_factor
-    new_freqs = []
-    for freq in freqs:
-        wavelen = 2 * math.pi / freq
-        if wavelen < high_freq_wavelen:
-            new_freqs.append(freq)
-        elif wavelen > low_freq_wavelen:
-            new_freqs.append(freq / scale_factor)
-        else:
-            assert low_freq_wavelen != high_freq_wavelen
-            smooth = (old_context_len / wavelen - low_freq_factor) / (
-                high_freq_factor - low_freq_factor
-            )
-            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+  low_freq_wavelen = old_context_len / low_freq_factor
+  high_freq_wavelen = old_context_len / high_freq_factor
+  new_freqs = []
+  for freq in freqs:
+    wavelen = 2 * math.pi / freq
+    if wavelen < high_freq_wavelen:
+      new_freqs.append(freq)
+    elif wavelen > low_freq_wavelen:
+      new_freqs.append(freq / scale_factor)
+    else:
+      assert low_freq_wavelen != high_freq_wavelen
+      smooth = (old_context_len / wavelen - low_freq_factor) / (
+          high_freq_factor - low_freq_factor)
+      new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+  return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
-def precompute_freqs_cis(
-    dim: int, end: int, theta: float = 10000.0, use_scaled: bool = False
-):
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
-    t = torch.arange(end, device=freqs.device, dtype=torch.float32)
-    if use_scaled:
-        freqs = apply_scaling(freqs)
-    freqs = torch.outer(t, freqs)
-    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
-    return freqs_cis
+def precompute_freqs_cis(dim: int,
+                         end: int,
+                         theta: float = 10000.0,
+                         use_scaled: bool = False):
+  freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
+  t = torch.arange(end, device=freqs.device, dtype=torch.float32)
+  if use_scaled:
+    freqs = apply_scaling(freqs)
+  freqs = torch.outer(t, freqs)
+  freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+  return freqs_cis
 
 
 def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
-    ndim = x.ndim
-    assert 0 <= 1 < ndim
-    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
-    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
-    return freqs_cis.view(*shape)
+  ndim = x.ndim
+  assert 0 <= 1 < ndim
+  assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+  shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+  return freqs_cis.view(*shape)
 
 
 def apply_rotary_emb(
     xq: torch.Tensor,
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
-    #return xq_out.type_as(xq), xk_out.type_as(xk)
-    return xq_out.to(torch.bfloat16), xk_out.to(torch.bfloat16)
+) -> tuple[torch.Tensor, torch.Tensor]:
+  xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+  xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+  freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+  xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+  xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+  # return xq_out.type_as(xq), xk_out.type_as(xk)
+  return xq_out.to(torch.bfloat16), xk_out.to(torch.bfloat16)
 
 
 def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
-    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
-    bs, slen, n_kv_heads, head_dim = x.shape
-    if n_rep == 1:
-        return x
-    return (
-        x[:, :, :, None, :]
-        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
-        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
-    )
+  """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+  bs, slen, n_kv_heads, head_dim = x.shape
+  if n_rep == 1:
+    return x
+  return (x[:, :, :,
+            None, :].expand(bs, slen, n_kv_heads, n_rep,
+                            head_dim).reshape(bs, slen, n_kv_heads * n_rep,
+                                              head_dim))
 
 
 class Attention(nn.Module):
-    def __init__(self, args: ModelArgs):
-        super().__init__()
-        self.n_kv_heads = args.n_heads if args.n_kv_heads is None else args.n_kv_heads
-        self.n_local_heads = args.n_heads
-        self.n_local_kv_heads = self.n_kv_heads
-        self.n_rep = self.n_local_heads // self.n_local_kv_heads
-        self.head_dim = args.dim // args.n_heads
 
-        self.wq = nn.Linear(
-            args.dim,
-            args.n_heads * self.head_dim,
-            bias=False,
-        )
-        self.wk = nn.Linear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-        )
-        self.wv = nn.Linear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-        )
-        self.wo = nn.Linear(
-            args.n_heads * self.head_dim,
-            args.dim,
-            bias=False,
-        )
+  def __init__(self, args: ModelArgs):
+    super().__init__()
+    self.n_kv_heads = (
+        args.n_heads if args.n_kv_heads is None else args.n_kv_heads)
+    self.n_local_heads = args.n_heads
+    self.n_local_kv_heads = self.n_kv_heads
+    self.n_rep = self.n_local_heads // self.n_local_kv_heads
+    self.head_dim = args.dim // args.n_heads
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        bsz, seqlen, _ = x.shape
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+    self.wq = nn.Linear(
+        args.dim,
+        args.n_heads * self.head_dim,
+        bias=False,
+    )
+    self.wk = nn.Linear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+    )
+    self.wv = nn.Linear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+    )
+    self.wo = nn.Linear(
+        args.n_heads * self.head_dim,
+        args.dim,
+        bias=False,
+    )
 
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    bsz, seqlen, _ = x.shape
+    xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
 
-        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+    xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+    xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+    xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
-        keys = xk
-        values = xv
+    xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
 
-        # repeat k/v heads if n_kv_heads < n_heads
-        keys = repeat_kv(
-            keys, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
-        values = repeat_kv(
-            values, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    keys = xk
+    values = xv
 
-        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
-        values = values.transpose(
-            1, 2
-        )  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    # repeat k/v heads if n_kv_heads < n_heads
+    keys = repeat_kv(
+        keys, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    values = repeat_kv(
+        values, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
 
-        output = torch.nn.functional.scaled_dot_product_attention(
-            xq, keys, values, is_causal=(mask is not None)
-        )
+    xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+    keys = keys.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    values = values.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
 
-        output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
-        return self.wo(output)
+    output = torch.nn.functional.scaled_dot_product_attention(
+        xq, keys, values, is_causal=(mask is not None))
+
+    output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+    return self.wo(output)
 
 
 class FeedForward(nn.Module):
-    def __init__(
-        self,
-        dim: int,
-        hidden_dim: int,
-        multiple_of: int,
-        ffn_dim_multiplier: Optional[float],
-    ):
-        super().__init__()
-        hidden_dim = int(2 * hidden_dim / 3)
-        # custom dim factor multiplier
-        if ffn_dim_multiplier is not None:
-            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
-        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-        self.w1 = nn.Linear(
-            dim, hidden_dim, bias=False,
-        )
-        self.w2 = nn.Linear(
-            hidden_dim, dim, bias=False,
-        )
-        self.w3 = nn.Linear(
-            dim, hidden_dim, bias=False,
-        )
+  def __init__(
+      self,
+      dim: int,
+      hidden_dim: int,
+      multiple_of: int,
+      ffn_dim_multiplier: float | None,
+  ):
+    super().__init__()
+    hidden_dim = int(2 * hidden_dim / 3)
+    # custom dim factor multiplier
+    if ffn_dim_multiplier is not None:
+      hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+    hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-    def forward(self, x):
-        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+    self.w1 = nn.Linear(
+        dim,
+        hidden_dim,
+        bias=False,
+    )
+    self.w2 = nn.Linear(
+        hidden_dim,
+        dim,
+        bias=False,
+    )
+    self.w3 = nn.Linear(
+        dim,
+        hidden_dim,
+        bias=False,
+    )
+
+  def forward(self, x):
+    return self.w2(F.silu(self.w1(x)) * self.w3(x))
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, layer_id: int, args: ModelArgs):
-        super().__init__()
-        self.n_heads = args.n_heads
-        self.dim = args.dim
-        self.head_dim = args.dim // args.n_heads
-        self.attention = Attention(args)
-        self.feed_forward = FeedForward(
-            dim=args.dim,
-            hidden_dim=4 * args.dim,
-            multiple_of=args.multiple_of,
-            ffn_dim_multiplier=args.ffn_dim_multiplier,
-        )
-        self.layer_id = layer_id
-        self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
-        self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
-        out = h + self.feed_forward(self.ffn_norm(h))
-        return out
+  def __init__(self, layer_id: int, args: ModelArgs):
+    super().__init__()
+    self.n_heads = args.n_heads
+    self.dim = args.dim
+    self.head_dim = args.dim // args.n_heads
+    self.attention = Attention(args)
+    self.feed_forward = FeedForward(
+        dim=args.dim,
+        hidden_dim=4 * args.dim,
+        multiple_of=args.multiple_of,
+        ffn_dim_multiplier=args.ffn_dim_multiplier,
+    )
+    self.layer_id = layer_id
+    self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
+    self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
+
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
+    out = h + self.feed_forward(self.ffn_norm(h))
+    return out
 
 
 class Transformer(nn.Module):
-    def __init__(self, params: ModelArgs):
-        super().__init__()
-        self.params = params
-        self.vocab_size = params.vocab_size
-        self.n_layers = params.n_layers
 
-        self.tok_embeddings = nn.Embedding(
-            params.vocab_size, params.dim,
-        )
+  def __init__(self, params: ModelArgs):
+    super().__init__()
+    self.params = params
+    self.vocab_size = params.vocab_size
+    self.n_layers = params.n_layers
 
-        self.layers = torch.nn.ModuleList()
-        for layer_id in range(params.n_layers):
-            self.layers.append(TransformerBlock(layer_id, params))
+    self.tok_embeddings = nn.Embedding(
+        params.vocab_size,
+        params.dim,
+    )
 
-        self.norm = RMSNorm(params.dim, eps=params.norm_eps)
-        self.output = nn.Linear(
-            params.dim, params.vocab_size, bias=False,
-        )
+    self.layers = torch.nn.ModuleList()
+    for layer_id in range(params.n_layers):
+      self.layers.append(TransformerBlock(layer_id, params))
 
+    self.norm = RMSNorm(params.dim, eps=params.norm_eps)
+    self.output = nn.Linear(
+        params.dim,
+        params.vocab_size,
+        bias=False,
+    )
 
-    def forward(self, tokens: torch.Tensor, start_pos: int, freqs_cis, mask):
-        _bsz, seqlen = tokens.shape
-        h = self.tok_embeddings(tokens)
-        for layer in self.layers:
-            h = layer(h, start_pos, freqs_cis, mask)
-        h = self.norm(h)
-        output = self.output(h)
-        return output
+  def forward(self, tokens: torch.Tensor, start_pos: int, freqs_cis, mask):
+    _bsz, seqlen = tokens.shape
+    h = self.tok_embeddings(tokens)
+    for layer in self.layers:
+      h = layer(h, start_pos, freqs_cis, mask)
+    h = self.norm(h)
+    output = self.output(h)
+    return output

--- a/torchprime/experimental/torchax_models/llama/model_original.py
+++ b/torchprime/experimental/torchax_models/llama/model_original.py
@@ -11,7 +11,6 @@
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/model.py
 
 import math
-from typing import Optional, Tuple
 
 import fairscale.nn.model_parallel.initialize as fs_init
 import torch
@@ -31,306 +30,317 @@ from ..api import ModelArgs
 
 
 class RMSNorm(torch.nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
 
-    def _norm(self, x):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+  def __init__(self, dim: int, eps: float = 1e-6):
+    super().__init__()
+    self.eps = eps
+    self.weight = nn.Parameter(torch.ones(dim))
 
-    def forward(self, x):
-        output = self._norm(x.float()).type_as(x)
-        return output * self.weight
+  def _norm(self, x):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+  def forward(self, x):
+    output = self._norm(x.float()).type_as(x)
+    return output * self.weight
 
 
 def apply_scaling(freqs: torch.Tensor):
-    # Values obtained from grid search
-    scale_factor = 8
-    low_freq_factor = 1
-    high_freq_factor = 4
-    old_context_len = 8192  # original llama3 length
+  # Values obtained from grid search
+  scale_factor = 8
+  low_freq_factor = 1
+  high_freq_factor = 4
+  old_context_len = 8192  # original llama3 length
 
-    low_freq_wavelen = old_context_len / low_freq_factor
-    high_freq_wavelen = old_context_len / high_freq_factor
-    new_freqs = []
-    for freq in freqs:
-        wavelen = 2 * math.pi / freq
-        if wavelen < high_freq_wavelen:
-            new_freqs.append(freq)
-        elif wavelen > low_freq_wavelen:
-            new_freqs.append(freq / scale_factor)
-        else:
-            assert low_freq_wavelen != high_freq_wavelen
-            smooth = (old_context_len / wavelen - low_freq_factor) / (
-                high_freq_factor - low_freq_factor
-            )
-            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+  low_freq_wavelen = old_context_len / low_freq_factor
+  high_freq_wavelen = old_context_len / high_freq_factor
+  new_freqs = []
+  for freq in freqs:
+    wavelen = 2 * math.pi / freq
+    if wavelen < high_freq_wavelen:
+      new_freqs.append(freq)
+    elif wavelen > low_freq_wavelen:
+      new_freqs.append(freq / scale_factor)
+    else:
+      assert low_freq_wavelen != high_freq_wavelen
+      smooth = (old_context_len / wavelen - low_freq_factor) / (
+          high_freq_factor - low_freq_factor)
+      new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+  return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
-def precompute_freqs_cis(
-    dim: int, end: int, theta: float = 10000.0, use_scaled: bool = False
-):
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
-    t = torch.arange(end, device=freqs.device, dtype=torch.float32)
-    if use_scaled:
-        freqs = apply_scaling(freqs)
-    freqs = torch.outer(t, freqs)
-    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
-    return freqs_cis
+def precompute_freqs_cis(dim: int,
+                         end: int,
+                         theta: float = 10000.0,
+                         use_scaled: bool = False):
+  freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
+  t = torch.arange(end, device=freqs.device, dtype=torch.float32)
+  if use_scaled:
+    freqs = apply_scaling(freqs)
+  freqs = torch.outer(t, freqs)
+  freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+  return freqs_cis
 
 
 def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
-    ndim = x.ndim
-    assert 0 <= 1 < ndim
-    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
-    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
-    return freqs_cis.view(*shape)
+  ndim = x.ndim
+  assert 0 <= 1 < ndim
+  assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+  shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+  return freqs_cis.view(*shape)
 
 
 def apply_rotary_emb(
     xq: torch.Tensor,
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
-    return xq_out.type_as(xq), xk_out.type_as(xk)
+) -> tuple[torch.Tensor, torch.Tensor]:
+  xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+  xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+  freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+  xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+  xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+  return xq_out.type_as(xq), xk_out.type_as(xk)
 
 
 def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
-    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
-    bs, slen, n_kv_heads, head_dim = x.shape
-    if n_rep == 1:
-        return x
-    return (
-        x[:, :, :, None, :]
-        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
-        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
-    )
+  """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+  bs, slen, n_kv_heads, head_dim = x.shape
+  if n_rep == 1:
+    return x
+  return (x[:, :, :,
+            None, :].expand(bs, slen, n_kv_heads, n_rep,
+                            head_dim).reshape(bs, slen, n_kv_heads * n_rep,
+                                              head_dim))
 
 
 class Attention(nn.Module):
-    def __init__(self, args: ModelArgs):
-        super().__init__()
-        self.n_kv_heads = args.n_heads if args.n_kv_heads is None else args.n_kv_heads
-        model_parallel_size = fs_init.get_model_parallel_world_size()
-        self.n_local_heads = args.n_heads // model_parallel_size
-        self.n_local_kv_heads = self.n_kv_heads // model_parallel_size
-        self.n_rep = self.n_local_heads // self.n_local_kv_heads
-        self.head_dim = args.dim // args.n_heads
 
-        self.wq = ColumnParallelLinear(
-            args.dim,
-            args.n_heads * self.head_dim,
-            bias=False,
-            gather_output=False,
-            init_method=lambda x: x,
-        )
-        self.wk = ColumnParallelLinear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-            gather_output=False,
-            init_method=lambda x: x,
-        )
-        self.wv = ColumnParallelLinear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-            gather_output=False,
-            init_method=lambda x: x,
-        )
-        self.wo = RowParallelLinear(
-            args.n_heads * self.head_dim,
-            args.dim,
-            bias=False,
-            input_is_parallel=True,
-            init_method=lambda x: x,
-        )
+  def __init__(self, args: ModelArgs):
+    super().__init__()
+    self.n_kv_heads = (
+        args.n_heads if args.n_kv_heads is None else args.n_kv_heads)
+    model_parallel_size = fs_init.get_model_parallel_world_size()
+    self.n_local_heads = args.n_heads // model_parallel_size
+    self.n_local_kv_heads = self.n_kv_heads // model_parallel_size
+    self.n_rep = self.n_local_heads // self.n_local_kv_heads
+    self.head_dim = args.dim // args.n_heads
 
-        self.cache_k = torch.zeros(
-            (
-                args.max_batch_size,
-                args.max_seq_len,
-                self.n_local_kv_heads,
-                self.head_dim,
-            )
-        ).cuda()
-        self.cache_v = torch.zeros(
-            (
-                args.max_batch_size,
-                args.max_seq_len,
-                self.n_local_kv_heads,
-                self.head_dim,
-            )
-        ).cuda()
+    self.wq = ColumnParallelLinear(
+        args.dim,
+        args.n_heads * self.head_dim,
+        bias=False,
+        gather_output=False,
+        init_method=lambda x: x,
+    )
+    self.wk = ColumnParallelLinear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+        gather_output=False,
+        init_method=lambda x: x,
+    )
+    self.wv = ColumnParallelLinear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+        gather_output=False,
+        init_method=lambda x: x,
+    )
+    self.wo = RowParallelLinear(
+        args.n_heads * self.head_dim,
+        args.dim,
+        bias=False,
+        input_is_parallel=True,
+        init_method=lambda x: x,
+    )
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        bsz, seqlen, _ = x.shape
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+    self.cache_k = torch.zeros((
+        args.max_batch_size,
+        args.max_seq_len,
+        self.n_local_kv_heads,
+        self.head_dim,
+    )).cuda()
+    self.cache_v = torch.zeros((
+        args.max_batch_size,
+        args.max_seq_len,
+        self.n_local_kv_heads,
+        self.head_dim,
+    )).cuda()
 
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    bsz, seqlen, _ = x.shape
+    xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
 
-        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+    xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+    xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+    xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
-        self.cache_k = self.cache_k.to(xq)
-        self.cache_v = self.cache_v.to(xq)
+    xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
 
-        self.cache_k[:bsz, start_pos : start_pos + seqlen] = xk
-        self.cache_v[:bsz, start_pos : start_pos + seqlen] = xv
+    self.cache_k = self.cache_k.to(xq)
+    self.cache_v = self.cache_v.to(xq)
 
-        keys = self.cache_k[:bsz, : start_pos + seqlen]
-        values = self.cache_v[:bsz, : start_pos + seqlen]
+    self.cache_k[:bsz, start_pos:start_pos + seqlen] = xk
+    self.cache_v[:bsz, start_pos:start_pos + seqlen] = xv
 
-        # repeat k/v heads if n_kv_heads < n_heads
-        keys = repeat_kv(
-            keys, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
-        values = repeat_kv(
-            values, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    keys = self.cache_k[:bsz, :start_pos + seqlen]
+    values = self.cache_v[:bsz, :start_pos + seqlen]
 
-        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
-        values = values.transpose(
-            1, 2
-        )  # (bs, n_local_heads, cache_len + seqlen, head_dim)
-        scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
-        if mask is not None:
-            scores = scores + mask  # (bs, n_local_heads, seqlen, cache_len + seqlen)
-        scores = F.softmax(scores.float(), dim=-1).type_as(xq)
-        output = torch.matmul(scores, values)  # (bs, n_local_heads, seqlen, head_dim)
-        output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
-        return self.wo(output)
+    # repeat k/v heads if n_kv_heads < n_heads
+    keys = repeat_kv(
+        keys, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    values = repeat_kv(
+        values, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+
+    xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+    keys = keys.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    values = values.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    scores = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
+    if mask is not None:
+      scores = (scores + mask
+               )  # (bs, n_local_heads, seqlen, cache_len + seqlen)
+    scores = F.softmax(scores.float(), dim=-1).type_as(xq)
+    output = torch.matmul(scores,
+                          values)  # (bs, n_local_heads, seqlen, head_dim)
+    output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+    return self.wo(output)
 
 
 class FeedForward(nn.Module):
-    def __init__(
-        self,
-        dim: int,
-        hidden_dim: int,
-        multiple_of: int,
-        ffn_dim_multiplier: Optional[float],
-    ):
-        super().__init__()
-        hidden_dim = int(2 * hidden_dim / 3)
-        # custom dim factor multiplier
-        if ffn_dim_multiplier is not None:
-            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
-        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-        self.w1 = ColumnParallelLinear(
-            dim, hidden_dim, bias=False, gather_output=False, init_method=lambda x: x
-        )
-        self.w2 = RowParallelLinear(
-            hidden_dim, dim, bias=False, input_is_parallel=True, init_method=lambda x: x
-        )
-        self.w3 = ColumnParallelLinear(
-            dim, hidden_dim, bias=False, gather_output=False, init_method=lambda x: x
-        )
+  def __init__(
+      self,
+      dim: int,
+      hidden_dim: int,
+      multiple_of: int,
+      ffn_dim_multiplier: float | None,
+  ):
+    super().__init__()
+    hidden_dim = int(2 * hidden_dim / 3)
+    # custom dim factor multiplier
+    if ffn_dim_multiplier is not None:
+      hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+    hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-    def forward(self, x):
-        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+    self.w1 = ColumnParallelLinear(
+        dim,
+        hidden_dim,
+        bias=False,
+        gather_output=False,
+        init_method=lambda x: x,
+    )
+    self.w2 = RowParallelLinear(
+        hidden_dim,
+        dim,
+        bias=False,
+        input_is_parallel=True,
+        init_method=lambda x: x,
+    )
+    self.w3 = ColumnParallelLinear(
+        dim,
+        hidden_dim,
+        bias=False,
+        gather_output=False,
+        init_method=lambda x: x,
+    )
+
+  def forward(self, x):
+    return self.w2(F.silu(self.w1(x)) * self.w3(x))
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, layer_id: int, args: ModelArgs):
-        super().__init__()
-        self.n_heads = args.n_heads
-        self.dim = args.dim
-        self.head_dim = args.dim // args.n_heads
-        self.attention = Attention(args)
-        self.feed_forward = FeedForward(
-            dim=args.dim,
-            hidden_dim=4 * args.dim,
-            multiple_of=args.multiple_of,
-            ffn_dim_multiplier=args.ffn_dim_multiplier,
-        )
-        self.layer_id = layer_id
-        self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
-        self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
-        out = h + self.feed_forward(self.ffn_norm(h))
-        return out
+  def __init__(self, layer_id: int, args: ModelArgs):
+    super().__init__()
+    self.n_heads = args.n_heads
+    self.dim = args.dim
+    self.head_dim = args.dim // args.n_heads
+    self.attention = Attention(args)
+    self.feed_forward = FeedForward(
+        dim=args.dim,
+        hidden_dim=4 * args.dim,
+        multiple_of=args.multiple_of,
+        ffn_dim_multiplier=args.ffn_dim_multiplier,
+    )
+    self.layer_id = layer_id
+    self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
+    self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
+
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
+    out = h + self.feed_forward(self.ffn_norm(h))
+    return out
 
 
 class Transformer(nn.Module):
-    def __init__(self, params: ModelArgs):
-        super().__init__()
-        self.params = params
-        self.vocab_size = params.vocab_size
-        self.n_layers = params.n_layers
 
-        self.tok_embeddings = VocabParallelEmbedding(
-            params.vocab_size, params.dim, init_method=lambda x: x
-        )
+  def __init__(self, params: ModelArgs):
+    super().__init__()
+    self.params = params
+    self.vocab_size = params.vocab_size
+    self.n_layers = params.n_layers
 
-        self.layers = torch.nn.ModuleList()
-        for layer_id in range(params.n_layers):
-            self.layers.append(TransformerBlock(layer_id, params))
+    self.tok_embeddings = VocabParallelEmbedding(
+        params.vocab_size, params.dim, init_method=lambda x: x)
 
-        self.norm = RMSNorm(params.dim, eps=params.norm_eps)
-        self.output = ColumnParallelLinear(
-            params.dim, params.vocab_size, bias=False, init_method=lambda x: x
-        )
+    self.layers = torch.nn.ModuleList()
+    for layer_id in range(params.n_layers):
+      self.layers.append(TransformerBlock(layer_id, params))
 
-        self.freqs_cis = precompute_freqs_cis(
-            params.dim // params.n_heads,
-            params.max_seq_len * 2,
-            params.rope_theta,
-            params.use_scaled_rope,
-        )
+    self.norm = RMSNorm(params.dim, eps=params.norm_eps)
+    self.output = ColumnParallelLinear(
+        params.dim, params.vocab_size, bias=False, init_method=lambda x: x)
 
-    @torch.inference_mode()
-    def forward(self, tokens: torch.Tensor, start_pos: int):
-        _bsz, seqlen = tokens.shape
-        h = self.tok_embeddings(tokens)
-        self.freqs_cis = self.freqs_cis.to(h.device)
-        freqs_cis = self.freqs_cis[start_pos : start_pos + seqlen]
+    self.freqs_cis = precompute_freqs_cis(
+        params.dim // params.n_heads,
+        params.max_seq_len * 2,
+        params.rope_theta,
+        params.use_scaled_rope,
+    )
 
-        mask = None
-        if seqlen > 1:
-            mask = torch.full((seqlen, seqlen), float("-inf"), device=tokens.device)
+  @torch.inference_mode()
+  def forward(self, tokens: torch.Tensor, start_pos: int):
+    _bsz, seqlen = tokens.shape
+    h = self.tok_embeddings(tokens)
+    self.freqs_cis = self.freqs_cis.to(h.device)
+    freqs_cis = self.freqs_cis[start_pos:start_pos + seqlen]
 
-            mask = torch.triu(mask, diagonal=1)
+    mask = None
+    if seqlen > 1:
+      mask = torch.full((seqlen, seqlen), float("-inf"), device=tokens.device)
 
-            # https://github.com/pytorch/pytorch/issues/100005
-            # torch.triu is buggy when the device is mps: filled values are 
-            # nan instead of 0. 
-            if mask.device.type == torch.device('mps').type:
-                mask = torch.nan_to_num(mask, nan=0.0)
+      mask = torch.triu(mask, diagonal=1)
 
-            # When performing key-value caching, we compute the attention scores
-            # only for the new sequence. Thus, the matrix of scores is of size
-            # (seqlen, cache_len + seqlen), and the only masked entries are (i, j) for
-            # j > cache_len + i, since row i corresponds to token cache_len + i.
-            mask = torch.hstack(
-                [torch.zeros((seqlen, start_pos), device=tokens.device), mask]
-            ).type_as(h)
+      # https://github.com/pytorch/pytorch/issues/100005
+      # torch.triu is buggy when the device is mps: filled values are
+      # nan instead of 0.
+      if mask.device.type == torch.device("mps").type:
+        mask = torch.nan_to_num(mask, nan=0.0)
 
-        for layer in self.layers:
-            h = layer(h, start_pos, freqs_cis, mask)
-        h = self.norm(h)
-        output = self.output(h).float()
-        return output
+      # When performing key-value caching, we compute the attention scores
+      # only for the new sequence. Thus, the matrix of scores is of size
+      # (seqlen, cache_len + seqlen), and the only masked entries are (i, j) for
+      # j > cache_len + i, since row i corresponds to token cache_len + i.
+      mask = torch.hstack(
+          [torch.zeros((seqlen, start_pos), device=tokens.device),
+           mask]).type_as(h)
+
+    for layer in self.layers:
+      h = layer(h, start_pos, freqs_cis, mask)
+    h = self.norm(h)
+    output = self.output(h).float()
+    return output

--- a/torchprime/experimental/torchax_models/llama/model_with_collectives.py
+++ b/torchprime/experimental/torchax_models/llama/model_with_collectives.py
@@ -10,19 +10,15 @@
 
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/model.py
 
-import functools
 import math
-from typing import Optional, Tuple
+from dataclasses import dataclass
 
+import jax
 import torch
 import torch.nn.functional as F
-from torch import nn
-from dataclasses import dataclass
-import jax
-from jax.sharding import PartitionSpec as P
-from torch_xla2 import interop
-
 from jax.ad_checkpoint import checkpoint_name
+from torch import nn
+from torch_xla2 import interop
 
 all_gather = interop.torch_view(jax.lax.all_gather)
 all_reduce_sum = interop.torch_view(jax.lax.psum)
@@ -30,35 +26,38 @@ all_reduce_sum = interop.torch_view(jax.lax.psum)
 
 @dataclass
 class ModelArgs:
-    dim: int = 4096
-    n_layers: int = 32
-    n_heads: int = 32
-    n_kv_heads: Optional[int] = None
-    vocab_size: int = -1
-    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
-    ffn_dim_multiplier: Optional[float] = None
-    norm_eps: float = 1e-5
-    rope_theta: float = 500000
-    use_scaled_rope: bool = False
+  dim: int = 4096
+  n_layers: int = 32
+  n_heads: int = 32
+  n_kv_heads: int | None = None
+  vocab_size: int = -1
+  multiple_of: int = (
+      256  # make SwiGLU hidden layer size multiple of large power of 2
+  )
+  ffn_dim_multiplier: float | None = None
+  norm_eps: float = 1e-5
+  rope_theta: float = 500000
+  use_scaled_rope: bool = False
 
-    max_batch_size: int = 32
-    max_seq_len: int = 8192
+  max_batch_size: int = 32
+  max_seq_len: int = 8192
 
-    # vision model params
-    vision_chunk_size: int = -1  # image resolution for image models
-    vision_max_num_chunks: int = 4
-    vision_num_cross_attention_layers: int = -1
+  # vision model params
+  vision_chunk_size: int = -1  # image resolution for image models
+  vision_max_num_chunks: int = 4
+  vision_num_cross_attention_layers: int = -1
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            if hasattr(self, k):
-                setattr(self, k, v)
+  def __init__(self, **kwargs):
+    for k, v in kwargs.items():
+      if hasattr(self, k):
+        setattr(self, k, v)
 
-        if self.n_kv_heads is None:
-            self.n_kv_heads = self.n_heads
-        assert self.n_kv_heads <= self.n_heads
-        assert self.n_heads % self.n_kv_heads == 0
-        assert self.dim % self.n_heads == 0
+    if self.n_kv_heads is None:
+      self.n_kv_heads = self.n_heads
+    assert self.n_kv_heads <= self.n_heads
+    assert self.n_heads % self.n_kv_heads == 0
+    assert self.dim % self.n_heads == 0
+
 
 # **NOTE**: This code is not runnable without installing `torch` and `fairscale`
 # dependencies. These dependencies are not part of the default dependencies
@@ -75,7 +74,7 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
+        "vocab_size": 128256,
     },
     "70B": {
         "dim": 8192,
@@ -87,7 +86,7 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
+        "vocab_size": 128256,
     },
     "405B": {
         "dim": 16384,
@@ -99,237 +98,245 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
-    }
+        "vocab_size": 128256,
+    },
 }
 
 
 class RMSNorm(torch.nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
 
-    def _norm(self, x):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+  def __init__(self, dim: int, eps: float = 1e-6):
+    super().__init__()
+    self.eps = eps
+    self.weight = nn.Parameter(torch.ones(dim))
 
-    def forward(self, x):
-        output = self._norm(x.float()).type_as(x)
-        return output * self.weight
+  def _norm(self, x):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+  def forward(self, x):
+    output = self._norm(x.float()).type_as(x)
+    return output * self.weight
 
 
 def apply_scaling(freqs: torch.Tensor):
-    # Values obtained from grid search
-    scale_factor = 8
-    low_freq_factor = 1
-    high_freq_factor = 4
-    old_context_len = 8192  # original llama3 length
+  # Values obtained from grid search
+  scale_factor = 8
+  low_freq_factor = 1
+  high_freq_factor = 4
+  old_context_len = 8192  # original llama3 length
 
-    low_freq_wavelen = old_context_len / low_freq_factor
-    high_freq_wavelen = old_context_len / high_freq_factor
-    new_freqs = []
-    for freq in freqs:
-        wavelen = 2 * math.pi / freq
-        if wavelen < high_freq_wavelen:
-            new_freqs.append(freq)
-        elif wavelen > low_freq_wavelen:
-            new_freqs.append(freq / scale_factor)
-        else:
-            assert low_freq_wavelen != high_freq_wavelen
-            smooth = (old_context_len / wavelen - low_freq_factor) / (
-                high_freq_factor - low_freq_factor
-            )
-            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+  low_freq_wavelen = old_context_len / low_freq_factor
+  high_freq_wavelen = old_context_len / high_freq_factor
+  new_freqs = []
+  for freq in freqs:
+    wavelen = 2 * math.pi / freq
+    if wavelen < high_freq_wavelen:
+      new_freqs.append(freq)
+    elif wavelen > low_freq_wavelen:
+      new_freqs.append(freq / scale_factor)
+    else:
+      assert low_freq_wavelen != high_freq_wavelen
+      smooth = (old_context_len / wavelen - low_freq_factor) / (
+          high_freq_factor - low_freq_factor)
+      new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+  return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
-def precompute_freqs_cis(
-    dim: int, end: int, theta: float = 10000.0, use_scaled: bool = False
-):
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
-    t = torch.arange(end, device=freqs.device, dtype=torch.float32)
-    if use_scaled:
-        freqs = apply_scaling(freqs)
-    freqs = torch.outer(t, freqs)
-    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
-    return freqs_cis
+def precompute_freqs_cis(dim: int,
+                         end: int,
+                         theta: float = 10000.0,
+                         use_scaled: bool = False):
+  freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
+  t = torch.arange(end, device=freqs.device, dtype=torch.float32)
+  if use_scaled:
+    freqs = apply_scaling(freqs)
+  freqs = torch.outer(t, freqs)
+  freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+  return freqs_cis
 
 
 def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
-    ndim = x.ndim
-    assert 0 <= 1 < ndim
-    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
-    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
-    return freqs_cis.view(*shape)
+  ndim = x.ndim
+  assert 0 <= 1 < ndim
+  assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+  shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+  return freqs_cis.view(*shape)
 
 
 def apply_rotary_emb(
     xq: torch.Tensor,
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
-    return xq_out.to(torch.bfloat16), xk_out.to(torch.bfloat16)
+) -> tuple[torch.Tensor, torch.Tensor]:
+  xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+  xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+  freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+  xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+  xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+  return xq_out.to(torch.bfloat16), xk_out.to(torch.bfloat16)
 
 
 def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
-    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
-    bs, slen, n_kv_heads, head_dim = x.shape
-    if n_rep == 1:
-        return x
-    return (
-        x[:, :, :, None, :]
-        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
-        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
-    )
+  """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+  bs, slen, n_kv_heads, head_dim = x.shape
+  if n_rep == 1:
+    return x
+  return (x[:, :, :,
+            None, :].expand(bs, slen, n_kv_heads, n_rep,
+                            head_dim).reshape(bs, slen, n_kv_heads * n_rep,
+                                              head_dim))
 
 
 class Attention(nn.Module):
-    def __init__(self, args: ModelArgs):
-        super().__init__()
-        self.n_kv_heads = args.n_heads if args.n_kv_heads is None else args.n_kv_heads
-        self.n_local_heads = args.n_heads // args.tp_size
-        self.n_local_kv_heads = self.n_kv_heads // args.tp_size
-        self.n_rep = self.n_local_heads // self.n_local_kv_heads
-        self.head_dim = args.dim // args.n_heads
 
-        self.wq = nn.Linear(
-            args.dim,
-            args.n_heads * self.head_dim,
-            bias=False,
-        )
-        self.wk = nn.Linear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-        )
-        self.wv = nn.Linear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-        )
-        self.wo = nn.Linear(
-            args.n_heads * self.head_dim,
-            args.dim,
-            bias=False,
-        )
+  def __init__(self, args: ModelArgs):
+    super().__init__()
+    self.n_kv_heads = (
+        args.n_heads if args.n_kv_heads is None else args.n_kv_heads)
+    self.n_local_heads = args.n_heads // args.tp_size
+    self.n_local_kv_heads = self.n_kv_heads // args.tp_size
+    self.n_rep = self.n_local_heads // self.n_local_kv_heads
+    self.head_dim = args.dim // args.n_heads
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        bsz, seqlen, _ = x.shape
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+    self.wq = nn.Linear(
+        args.dim,
+        args.n_heads * self.head_dim,
+        bias=False,
+    )
+    self.wk = nn.Linear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+    )
+    self.wv = nn.Linear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+    )
+    self.wo = nn.Linear(
+        args.n_heads * self.head_dim,
+        args.dim,
+        bias=False,
+    )
 
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    bsz, seqlen, _ = x.shape
+    xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
 
-        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+    xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+    xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+    xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
-        xq = interop.call_jax(checkpoint_name, xq, 'query_proj')
-        xk = interop.call_jax(checkpoint_name, xk, 'key_proj')
-        xv = interop.call_jax(checkpoint_name, xv, 'value_proj')
+    xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
 
-        keys = xk
-        values = xv
+    xq = interop.call_jax(checkpoint_name, xq, "query_proj")
+    xk = interop.call_jax(checkpoint_name, xk, "key_proj")
+    xv = interop.call_jax(checkpoint_name, xv, "value_proj")
 
-        # repeat k/v heads if n_kv_heads < n_heads
-        keys = repeat_kv(
-            keys, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
-        values = repeat_kv(
-            values, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    keys = xk
+    values = xv
 
-        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
-        values = values.transpose(
-            1, 2
-        )  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    # repeat k/v heads if n_kv_heads < n_heads
+    keys = repeat_kv(
+        keys, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    values = repeat_kv(
+        values, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
 
-        output = torch.nn.functional.scaled_dot_product_attention(
-            xq, keys, values, is_causal=(mask is not None)
-        )
+    xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+    keys = keys.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    values = values.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
 
-        output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
-        out = self.wo(output)
-        out = all_reduce_sum(out, axis_name='tp')
-        out = interop.call_jax(checkpoint_name, out, 'out_proj')
-        return out
+    output = torch.nn.functional.scaled_dot_product_attention(
+        xq, keys, values, is_causal=(mask is not None))
+
+    output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+    out = self.wo(output)
+    out = all_reduce_sum(out, axis_name="tp")
+    out = interop.call_jax(checkpoint_name, out, "out_proj")
+    return out
 
 
 class FeedForward(nn.Module):
-    def __init__(
-        self,
-        dim: int,
-        hidden_dim: int,
-        multiple_of: int,
-        ffn_dim_multiplier: Optional[float],
-    ):
-        super().__init__()
-        hidden_dim = int(2 * hidden_dim / 3)
-        # custom dim factor multiplier
-        if ffn_dim_multiplier is not None:
-            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
-        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-        self.w1 = nn.Linear(
-            dim, hidden_dim, bias=False,
-        )
-        self.w2 = nn.Linear(
-            hidden_dim, dim, bias=False,
-        )
-        self.w3 = nn.Linear(
-            dim, hidden_dim, bias=False,
-        )
+  def __init__(
+      self,
+      dim: int,
+      hidden_dim: int,
+      multiple_of: int,
+      ffn_dim_multiplier: float | None,
+  ):
+    super().__init__()
+    hidden_dim = int(2 * hidden_dim / 3)
+    # custom dim factor multiplier
+    if ffn_dim_multiplier is not None:
+      hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+    hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-    def forward(self, x):
-        wi1 = self.w1(x)
-        wi3 = self.w3(x)
-        wi1 = interop.call_jax(checkpoint_name, wi1, 'mlpwi')
-        wi3 = interop.call_jax(checkpoint_name, wi3, 'mlpwi')
-        output = self.w2(F.silu(wi1) * wi3)
-        output = all_reduce_sum(output, axis_name='tp')
-        output = interop.call_jax(checkpoint_name, output, 'mlpwo')
-        return output
+    self.w1 = nn.Linear(
+        dim,
+        hidden_dim,
+        bias=False,
+    )
+    self.w2 = nn.Linear(
+        hidden_dim,
+        dim,
+        bias=False,
+    )
+    self.w3 = nn.Linear(
+        dim,
+        hidden_dim,
+        bias=False,
+    )
+
+  def forward(self, x):
+    wi1 = self.w1(x)
+    wi3 = self.w3(x)
+    wi1 = interop.call_jax(checkpoint_name, wi1, "mlpwi")
+    wi3 = interop.call_jax(checkpoint_name, wi3, "mlpwi")
+    output = self.w2(F.silu(wi1) * wi3)
+    output = all_reduce_sum(output, axis_name="tp")
+    output = interop.call_jax(checkpoint_name, output, "mlpwo")
+    return output
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, layer_id: int, args: ModelArgs):
-        super().__init__()
-        self.n_heads = args.n_heads
-        self.dim = args.dim
-        self.head_dim = args.dim // args.n_heads
-        self.attention = Attention(args)
-        self.feed_forward = FeedForward(
-            dim=args.dim,
-            hidden_dim=4 * args.dim,
-            multiple_of=args.multiple_of,
-            ffn_dim_multiplier=args.ffn_dim_multiplier,
-        )
-        self.layer_id = layer_id
-        self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
-        self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        x = interop.call_jax(checkpoint_name, x, 'decoder_layer_input')
-        h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
-        out = h + self.feed_forward(self.ffn_norm(h))
-        return out
+  def __init__(self, layer_id: int, args: ModelArgs):
+    super().__init__()
+    self.n_heads = args.n_heads
+    self.dim = args.dim
+    self.head_dim = args.dim // args.n_heads
+    self.attention = Attention(args)
+    self.feed_forward = FeedForward(
+        dim=args.dim,
+        hidden_dim=4 * args.dim,
+        multiple_of=args.multiple_of,
+        ffn_dim_multiplier=args.ffn_dim_multiplier,
+    )
+    self.layer_id = layer_id
+    self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
+    self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
+
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    x = interop.call_jax(checkpoint_name, x, "decoder_layer_input")
+    h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
+    out = h + self.feed_forward(self.ffn_norm(h))
+    return out
+
 
 #   "layers.*.attention.wo.weight" : ('fsdp', 'tp'), #  torch.int8 (4096, 4096)
 #   "layers.*.attention.wq.weight" : ('tp', 'fsdp'), #  torch.int8 (4096, 4096)
@@ -340,133 +347,139 @@ class TransformerBlock(nn.Module):
 #   "layers.*.feed_forward.w3.weight": ('tp', 'fsdp'), #  torch.float32 (11008, 4096)
 #   "layers.*.attention_norm.weight" : ('fsdp', ), #  torch.float32 (4096,)
 def _fsdp_axis(name):
-    if any(key in name for key in ('wq', 'wk', 'wv', 'w1', 'w3')):
-        return 1
-    else:
-        return 0
+  if any(key in name for key in ("wq", "wk", "wv", "w1", "w3")):
+    return 1
+  else:
+    return 0
 
 
 class ScanLayer(nn.Module):
+  # requirement: submodule's return value must be the same type/shape as input
 
-    # requirement: submodule's return value must be the same type/shape as input
-    
+  def __init__(self, submodule: nn.Module, num_layers: int, unroll_layers: int):
+    super().__init__()
+    self.m = submodule
+    self.num_layers = num_layers
+    self.unroll_layers = unroll_layers
+    one_block_statedict = self.m.state_dict()
+    self.layer_weights_keys = list(one_block_statedict.keys())
+    stacked_weights = self._stack_layer_weights(one_block_statedict, num_layers)
+    # register those as parameters on this module
 
-    def __init__(self, submodule: nn.Module, num_layers: int, unroll_layers: int):
-        super().__init__()
-        self.m = submodule
-        self.num_layers = num_layers
-        self.unroll_layers = unroll_layers
-        one_block_statedict = self.m.state_dict()
-        self.layer_weights_keys = list(one_block_statedict.keys())
-        stacked_weights = self._stack_layer_weights(one_block_statedict, num_layers)
-        # register those as parameters on this module
+    self.params = nn.ParameterDict({
+        self._param_name_new(k): nn.Parameter(v)
+        for k, v in stacked_weights.items()
+    })
 
-        self.params = nn.ParameterDict(
-            {self._param_name_new(k): nn.Parameter(v) for k, v in stacked_weights.items()}
-        )
+    # self._eval_one_layer = eval_one_layer
 
-        #self._eval_one_layer = eval_one_layer
+  def _stack_layer_weights(self, orig_state_dict, num_layers):
+    # Create weights such that, for every [n, m] weights
+    # becomes [k, n, m] where k is number of layer
+    # i.e. stacking layer weights together
+    temp = {}
+    for k, v in orig_state_dict.items():
+      newv = torch.stack([v for _ in range(num_layers)])
+      temp[k] = newv
+    return temp
 
-    def _stack_layer_weights(self, orig_state_dict, num_layers):
-        # Create weights such that, for every [n, m] weights
-        # becomes [k, n, m] where k is number of layer
-        # i.e. stacking layer weights together
-        temp = {}
-        for k, v in orig_state_dict.items():
-            newv = torch.stack([v for _ in range(num_layers)])
-            temp[k] = newv
-        return temp
+  def _param_name_new(self, old):
+    return "___".join(old.split("."))
 
+  def _param_name_old(self, new):
+    return ".".join(new.split("___"))
 
-    def _param_name_new(self, old):
-        return '___'.join(old.split('.'))
+  def forward(self, *args, **kwargs):
+    assert not kwargs
+    weights = {
+        k: self.params[self._param_name_new(k)] for k in self.layer_weights_keys
+    }
+    scan = interop.torch_view(jax.lax.scan)
+    rest = args[1:]
 
-    def _param_name_old(self, new):
-        return '.'.join(new.split('___'))
+    def eval_one_layer(h, weight):
+      # unpack args
+      def gather_and_call(h, new_weights):
+        gathered = {}
+        for k, val in new_weights.items():
+          gathered[k] = all_gather(
+              val, axis=_fsdp_axis(k), axis_name="fsdp", tiled=True)
+        newh = torch.func.functional_call(self.m, gathered, (h, *rest))
+        return newh
 
-    def forward(self, *args, **kwargs):
-        assert not kwargs
-        weights = {k: self.params[self._param_name_new(k)] for k in self.layer_weights_keys}
-        scan = interop.torch_view(jax.lax.scan)
-        rest = args[1:]
+      for i in range(self.unroll_layers):
+        new_weights = {}
+        for k, v in weight.items():
+          new_weights[k] = v[i]
+        h = gather_and_call(h, new_weights)
+      # next layer's input; and residual to be added to list
+      return h, torch.ones(1)
 
-        def eval_one_layer(h, weight):
-            # unpack args
-            def gather_and_call(h, new_weights):
-                gathered = {}
-                for k, val in new_weights.items():
-                    gathered[k] = all_gather(val, axis=_fsdp_axis(k), axis_name='fsdp', tiled=True)
-                newh = torch.func.functional_call(self.m, gathered, (h, *rest))
-                return newh
-            
-            for i in range(self.unroll_layers):
-                new_weights = {}
-                for k, v in weight.items():
-                    new_weights[k] = v[i]
-                h = gather_and_call(h, new_weights)
-            # next layer's input; and residual to be added to list
-            return h, torch.ones(1)
-
-
-        policy = jax.checkpoint_policies.save_and_offload_only_these_names(
-            names_which_can_be_saved=[],
-            names_which_can_be_offloaded=[
-                "decoder_layer_input",
-                "query_proj",
-                "key_proj",
-                "value_proj",
-                "out_proj",
-            ],
-            offload_src="device",
-            offload_dst="pinned_host",
-        )
-        _eval_one_layer = interop.call_jax(
-            jax.checkpoint, 
-            eval_one_layer,
-            policy=policy,
-        )
-        reshaped_weights = {}
-        for k, v in weights.items():
-            shape = v.shape
-            reshaped_weights[k] = v.reshape(shape[0] // self.unroll_layers, self.unroll_layers, *shape[1:])
-        h, _ = scan(
-            _eval_one_layer,
-            args[0],
-            reshaped_weights,
-        )
-        return h
-
-
-
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=[],
+        names_which_can_be_offloaded=[
+            "decoder_layer_input",
+            "query_proj",
+            "key_proj",
+            "value_proj",
+            "out_proj",
+        ],
+        offload_src="device",
+        offload_dst="pinned_host",
+    )
+    _eval_one_layer = interop.call_jax(
+        jax.checkpoint,
+        eval_one_layer,
+        policy=policy,
+    )
+    reshaped_weights = {}
+    for k, v in weights.items():
+      shape = v.shape
+      reshaped_weights[k] = v.reshape(shape[0] // self.unroll_layers,
+                                      self.unroll_layers, *shape[1:])
+    h, _ = scan(
+        _eval_one_layer,
+        args[0],
+        reshaped_weights,
+    )
+    return h
 
 
 class Transformer(nn.Module):
-    def __init__(self, params: ModelArgs, unroll_layers):
-        super().__init__()
-        self.params = params
-        self.vocab_size = params.vocab_size
-        self.n_layers = params.n_layers
 
-        self.tok_embeddings = nn.Embedding(
-            params.vocab_size, params.dim,
-        )
+  def __init__(self, params: ModelArgs, unroll_layers):
+    super().__init__()
+    self.params = params
+    self.vocab_size = params.vocab_size
+    self.n_layers = params.n_layers
 
-        # self.layers = torch.nn.ModuleList()
-        # for layer_id in range(params.n_layers):
-        #     self.layers.append(TransformerBlock(layer_id, params))
-        self.layers = ScanLayer(TransformerBlock(0, params), params.n_layers, unroll_layers=unroll_layers)
+    self.tok_embeddings = nn.Embedding(
+        params.vocab_size,
+        params.dim,
+    )
 
-        self.norm = RMSNorm(params.dim, eps=params.norm_eps)
-        self.output = nn.Linear(
-            params.dim, params.vocab_size, bias=False,
-        )
+    # self.layers = torch.nn.ModuleList()
+    # for layer_id in range(params.n_layers):
+    #     self.layers.append(TransformerBlock(layer_id, params))
+    self.layers = ScanLayer(
+        TransformerBlock(0, params),
+        params.n_layers,
+        unroll_layers=unroll_layers,
+    )
 
-    def forward(self, tokens: torch.Tensor, start_pos: int, freqs_cis, mask):
-        _bsz, seqlen = tokens.shape
-        h = self.tok_embeddings(tokens)
-        h = all_gather(h, axis_name='tp', tiled=True, axis=2)
-        h = self.layers(h, start_pos, freqs_cis, mask)
-        h = self.norm(h)
-        output = self.output(h)
-        output = all_gather(output, axis_name='tp', tiled=True, axis=2)
-        return output
+    self.norm = RMSNorm(params.dim, eps=params.norm_eps)
+    self.output = nn.Linear(
+        params.dim,
+        params.vocab_size,
+        bias=False,
+    )
+
+  def forward(self, tokens: torch.Tensor, start_pos: int, freqs_cis, mask):
+    _bsz, seqlen = tokens.shape
+    h = self.tok_embeddings(tokens)
+    h = all_gather(h, axis_name="tp", tiled=True, axis=2)
+    h = self.layers(h, start_pos, freqs_cis, mask)
+    h = self.norm(h)
+    output = self.output(h)
+    output = all_gather(output, axis_name="tp", tiled=True, axis=2)
+    return output

--- a/torchprime/experimental/torchax_models/llama/model_with_scan.py
+++ b/torchprime/experimental/torchax_models/llama/model_with_scan.py
@@ -10,53 +10,54 @@
 
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/model.py
 
-import functools
 import math
-from typing import Optional, Tuple
+from dataclasses import dataclass
 
+import jax
 import torch
 import torch.nn.functional as F
-from torch import nn
-from dataclasses import dataclass
-import jax
-from jax.sharding import PartitionSpec as P
-from torch_xla2 import interop
-
 from jax.ad_checkpoint import checkpoint_name
+from jax.sharding import PartitionSpec as P
+from torch import nn
+from torch_xla2 import interop
 
 with_sharding_constraint = interop.torch_view(jax.lax.with_sharding_constraint)
 
+
 @dataclass
 class ModelArgs:
-    dim: int = 4096
-    n_layers: int = 32
-    n_heads: int = 32
-    n_kv_heads: Optional[int] = None
-    vocab_size: int = -1
-    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
-    ffn_dim_multiplier: Optional[float] = None
-    norm_eps: float = 1e-5
-    rope_theta: float = 500000
-    use_scaled_rope: bool = False
+  dim: int = 4096
+  n_layers: int = 32
+  n_heads: int = 32
+  n_kv_heads: int | None = None
+  vocab_size: int = -1
+  multiple_of: int = (
+      256  # make SwiGLU hidden layer size multiple of large power of 2
+  )
+  ffn_dim_multiplier: float | None = None
+  norm_eps: float = 1e-5
+  rope_theta: float = 500000
+  use_scaled_rope: bool = False
 
-    max_batch_size: int = 32
-    max_seq_len: int = 8192
+  max_batch_size: int = 32
+  max_seq_len: int = 8192
 
-    # vision model params
-    vision_chunk_size: int = -1  # image resolution for image models
-    vision_max_num_chunks: int = 4
-    vision_num_cross_attention_layers: int = -1
+  # vision model params
+  vision_chunk_size: int = -1  # image resolution for image models
+  vision_max_num_chunks: int = 4
+  vision_num_cross_attention_layers: int = -1
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            if hasattr(self, k):
-                setattr(self, k, v)
+  def __init__(self, **kwargs):
+    for k, v in kwargs.items():
+      if hasattr(self, k):
+        setattr(self, k, v)
 
-        if self.n_kv_heads is None:
-            self.n_kv_heads = self.n_heads
-        assert self.n_kv_heads <= self.n_heads
-        assert self.n_heads % self.n_kv_heads == 0
-        assert self.dim % self.n_heads == 0
+    if self.n_kv_heads is None:
+      self.n_kv_heads = self.n_heads
+    assert self.n_kv_heads <= self.n_heads
+    assert self.n_heads % self.n_kv_heads == 0
+    assert self.dim % self.n_heads == 0
+
 
 # **NOTE**: This code is not runnable without installing `torch` and `fairscale`
 # dependencies. These dependencies are not part of the default dependencies
@@ -73,7 +74,7 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
+        "vocab_size": 128256,
     },
     "70B": {
         "dim": 8192,
@@ -85,7 +86,7 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
+        "vocab_size": 128256,
     },
     "405B": {
         "dim": 16384,
@@ -97,341 +98,350 @@ transformer_configs = {
         "norm_eps": 1e-05,
         "rope_theta": 500000.0,
         "use_scaled_rope": True,
-        "vocab_size": 128256
-    }
+        "vocab_size": 128256,
+    },
 }
 
 
 class RMSNorm(torch.nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
 
-    def _norm(self, x):
-        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+  def __init__(self, dim: int, eps: float = 1e-6):
+    super().__init__()
+    self.eps = eps
+    self.weight = nn.Parameter(torch.ones(dim))
 
-    def forward(self, x):
-        output = self._norm(x.float()).type_as(x)
-        return output * self.weight
+  def _norm(self, x):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+  def forward(self, x):
+    output = self._norm(x.float()).type_as(x)
+    return output * self.weight
 
 
 def apply_scaling(freqs: torch.Tensor):
-    # Values obtained from grid search
-    scale_factor = 8
-    low_freq_factor = 1
-    high_freq_factor = 4
-    old_context_len = 8192  # original llama3 length
+  # Values obtained from grid search
+  scale_factor = 8
+  low_freq_factor = 1
+  high_freq_factor = 4
+  old_context_len = 8192  # original llama3 length
 
-    low_freq_wavelen = old_context_len / low_freq_factor
-    high_freq_wavelen = old_context_len / high_freq_factor
-    new_freqs = []
-    for freq in freqs:
-        wavelen = 2 * math.pi / freq
-        if wavelen < high_freq_wavelen:
-            new_freqs.append(freq)
-        elif wavelen > low_freq_wavelen:
-            new_freqs.append(freq / scale_factor)
-        else:
-            assert low_freq_wavelen != high_freq_wavelen
-            smooth = (old_context_len / wavelen - low_freq_factor) / (
-                high_freq_factor - low_freq_factor
-            )
-            new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
-    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+  low_freq_wavelen = old_context_len / low_freq_factor
+  high_freq_wavelen = old_context_len / high_freq_factor
+  new_freqs = []
+  for freq in freqs:
+    wavelen = 2 * math.pi / freq
+    if wavelen < high_freq_wavelen:
+      new_freqs.append(freq)
+    elif wavelen > low_freq_wavelen:
+      new_freqs.append(freq / scale_factor)
+    else:
+      assert low_freq_wavelen != high_freq_wavelen
+      smooth = (old_context_len / wavelen - low_freq_factor) / (
+          high_freq_factor - low_freq_factor)
+      new_freqs.append((1 - smooth) * freq / scale_factor + smooth * freq)
+  return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 
-def precompute_freqs_cis(
-    dim: int, end: int, theta: float = 10000.0, use_scaled: bool = False
-):
-    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
-    t = torch.arange(end, device=freqs.device, dtype=torch.float32)
-    if use_scaled:
-        freqs = apply_scaling(freqs)
-    freqs = torch.outer(t, freqs)
-    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
-    return freqs_cis
+def precompute_freqs_cis(dim: int,
+                         end: int,
+                         theta: float = 10000.0,
+                         use_scaled: bool = False):
+  freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
+  t = torch.arange(end, device=freqs.device, dtype=torch.float32)
+  if use_scaled:
+    freqs = apply_scaling(freqs)
+  freqs = torch.outer(t, freqs)
+  freqs_cis = torch.polar(torch.ones_like(freqs), freqs)  # complex64
+  return freqs_cis
 
 
 def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
-    ndim = x.ndim
-    assert 0 <= 1 < ndim
-    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
-    shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
-    return freqs_cis.view(*shape)
+  ndim = x.ndim
+  assert 0 <= 1 < ndim
+  assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+  shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
+  return freqs_cis.view(*shape)
 
 
 def apply_rotary_emb(
     xq: torch.Tensor,
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
-    return xq_out.to(torch.bfloat16), xk_out.to(torch.bfloat16)
+) -> tuple[torch.Tensor, torch.Tensor]:
+  xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+  xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+  freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
+  xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+  xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+  return xq_out.to(torch.bfloat16), xk_out.to(torch.bfloat16)
 
 
 def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
-    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
-    bs, slen, n_kv_heads, head_dim = x.shape
-    if n_rep == 1:
-        return x
-    return (
-        x[:, :, :, None, :]
-        .expand(bs, slen, n_kv_heads, n_rep, head_dim)
-        .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
-    )
+  """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+  bs, slen, n_kv_heads, head_dim = x.shape
+  if n_rep == 1:
+    return x
+  return (x[:, :, :,
+            None, :].expand(bs, slen, n_kv_heads, n_rep,
+                            head_dim).reshape(bs, slen, n_kv_heads * n_rep,
+                                              head_dim))
 
 
 class Attention(nn.Module):
-    def __init__(self, args: ModelArgs):
-        super().__init__()
-        self.n_kv_heads = args.n_heads if args.n_kv_heads is None else args.n_kv_heads
-        self.n_local_heads = args.n_heads
-        self.n_local_kv_heads = self.n_kv_heads
-        self.n_rep = self.n_local_heads // self.n_local_kv_heads
-        self.head_dim = args.dim // args.n_heads
 
-        self.wq = nn.Linear(
-            args.dim,
-            args.n_heads * self.head_dim,
-            bias=False,
-        )
-        self.wk = nn.Linear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-        )
-        self.wv = nn.Linear(
-            args.dim,
-            self.n_kv_heads * self.head_dim,
-            bias=False,
-        )
-        self.wo = nn.Linear(
-            args.n_heads * self.head_dim,
-            args.dim,
-            bias=False,
-        )
+  def __init__(self, args: ModelArgs):
+    super().__init__()
+    self.n_kv_heads = (
+        args.n_heads if args.n_kv_heads is None else args.n_kv_heads)
+    self.n_local_heads = args.n_heads
+    self.n_local_kv_heads = self.n_kv_heads
+    self.n_rep = self.n_local_heads // self.n_local_kv_heads
+    self.head_dim = args.dim // args.n_heads
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        bsz, seqlen, _ = x.shape
-        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+    self.wq = nn.Linear(
+        args.dim,
+        args.n_heads * self.head_dim,
+        bias=False,
+    )
+    self.wk = nn.Linear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+    )
+    self.wv = nn.Linear(
+        args.dim,
+        self.n_kv_heads * self.head_dim,
+        bias=False,
+    )
+    self.wo = nn.Linear(
+        args.n_heads * self.head_dim,
+        args.dim,
+        bias=False,
+    )
 
-        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
-        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
-        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    bsz, seqlen, _ = x.shape
+    xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
 
-        xq = with_sharding_constraint(xq, P('fsdp', None, 'tp', None))
-        xk = with_sharding_constraint(xk, P('fsdp', None, 'tp', None))
-        xv = with_sharding_constraint(xv, P('fsdp', None, 'tp', None))
+    xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+    xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+    xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
 
-        #xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
+    xq = with_sharding_constraint(xq, P("fsdp", None, "tp", None))
+    xk = with_sharding_constraint(xk, P("fsdp", None, "tp", None))
+    xv = with_sharding_constraint(xv, P("fsdp", None, "tp", None))
 
-        xq = interop.call_jax(checkpoint_name, xq, 'query_proj')
-        xk = interop.call_jax(checkpoint_name, xk, 'key_proj')
-        xv = interop.call_jax(checkpoint_name, xv, 'value_proj')
+    # xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis)
 
-        keys = xk
-        values = xv
+    xq = interop.call_jax(checkpoint_name, xq, "query_proj")
+    xk = interop.call_jax(checkpoint_name, xk, "key_proj")
+    xv = interop.call_jax(checkpoint_name, xv, "value_proj")
 
-        # repeat k/v heads if n_kv_heads < n_heads
-        keys = repeat_kv(
-            keys, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
-        values = repeat_kv(
-            values, self.n_rep
-        )  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    keys = xk
+    values = xv
 
-        xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
-        keys = keys.transpose(1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
-        values = values.transpose(
-            1, 2
-        )  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    # repeat k/v heads if n_kv_heads < n_heads
+    keys = repeat_kv(
+        keys, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+    values = repeat_kv(
+        values, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
 
-        output = torch.nn.functional.scaled_dot_product_attention(
-            xq, keys, values, is_causal=(mask is not None)
-        )
+    xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
+    keys = keys.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
+    values = values.transpose(
+        1, 2)  # (bs, n_local_heads, cache_len + seqlen, head_dim)
 
-        output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
-        out = self.wo(output)
-        out = with_sharding_constraint(out, P('fsdp', None, None))
-        out = interop.call_jax(checkpoint_name, out, 'out_proj')
-        return out
+    output = torch.nn.functional.scaled_dot_product_attention(
+        xq, keys, values, is_causal=(mask is not None))
+
+    output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+    out = self.wo(output)
+    out = with_sharding_constraint(out, P("fsdp", None, None))
+    out = interop.call_jax(checkpoint_name, out, "out_proj")
+    return out
 
 
 class FeedForward(nn.Module):
-    def __init__(
-        self,
-        dim: int,
-        hidden_dim: int,
-        multiple_of: int,
-        ffn_dim_multiplier: Optional[float],
-    ):
-        super().__init__()
-        hidden_dim = int(2 * hidden_dim / 3)
-        # custom dim factor multiplier
-        if ffn_dim_multiplier is not None:
-            hidden_dim = int(ffn_dim_multiplier * hidden_dim)
-        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-        self.w1 = nn.Linear(
-            dim, hidden_dim, bias=False,
-        )
-        self.w2 = nn.Linear(
-            hidden_dim, dim, bias=False,
-        )
-        self.w3 = nn.Linear(
-            dim, hidden_dim, bias=False,
-        )
+  def __init__(
+      self,
+      dim: int,
+      hidden_dim: int,
+      multiple_of: int,
+      ffn_dim_multiplier: float | None,
+  ):
+    super().__init__()
+    hidden_dim = int(2 * hidden_dim / 3)
+    # custom dim factor multiplier
+    if ffn_dim_multiplier is not None:
+      hidden_dim = int(ffn_dim_multiplier * hidden_dim)
+    hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
 
-    def forward(self, x):
-        wi1 = self.w1(x)
-        wi3 = self.w3(x)
-        wi1 = interop.call_jax(checkpoint_name, wi1, 'mlpwi')
-        wi3 = interop.call_jax(checkpoint_name, wi3, 'mlpwi')
-        output = self.w2(F.silu(wi1) * wi3)
-        output = interop.call_jax(checkpoint_name, output, 'mlpwo')
-        return output
+    self.w1 = nn.Linear(
+        dim,
+        hidden_dim,
+        bias=False,
+    )
+    self.w2 = nn.Linear(
+        hidden_dim,
+        dim,
+        bias=False,
+    )
+    self.w3 = nn.Linear(
+        dim,
+        hidden_dim,
+        bias=False,
+    )
+
+  def forward(self, x):
+    wi1 = self.w1(x)
+    wi3 = self.w3(x)
+    wi1 = interop.call_jax(checkpoint_name, wi1, "mlpwi")
+    wi3 = interop.call_jax(checkpoint_name, wi3, "mlpwi")
+    output = self.w2(F.silu(wi1) * wi3)
+    output = interop.call_jax(checkpoint_name, output, "mlpwo")
+    return output
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, layer_id: int, args: ModelArgs):
-        super().__init__()
-        self.n_heads = args.n_heads
-        self.dim = args.dim
-        self.head_dim = args.dim // args.n_heads
-        self.attention = Attention(args)
-        self.feed_forward = FeedForward(
-            dim=args.dim,
-            hidden_dim=4 * args.dim,
-            multiple_of=args.multiple_of,
-            ffn_dim_multiplier=args.ffn_dim_multiplier,
-        )
-        self.layer_id = layer_id
-        self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
-        self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
-    ):
-        x = interop.call_jax(checkpoint_name, x, 'decoder_layer_input')
-        h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
-        out = h + self.feed_forward(self.ffn_norm(h))
-        return out
+  def __init__(self, layer_id: int, args: ModelArgs):
+    super().__init__()
+    self.n_heads = args.n_heads
+    self.dim = args.dim
+    self.head_dim = args.dim // args.n_heads
+    self.attention = Attention(args)
+    self.feed_forward = FeedForward(
+        dim=args.dim,
+        hidden_dim=4 * args.dim,
+        multiple_of=args.multiple_of,
+        ffn_dim_multiplier=args.ffn_dim_multiplier,
+    )
+    self.layer_id = layer_id
+    self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)
+    self.ffn_norm = RMSNorm(args.dim, eps=args.norm_eps)
+
+  def forward(
+      self,
+      x: torch.Tensor,
+      start_pos: int,
+      freqs_cis: torch.Tensor,
+      mask: torch.Tensor | None,
+  ):
+    x = interop.call_jax(checkpoint_name, x, "decoder_layer_input")
+    h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
+    out = h + self.feed_forward(self.ffn_norm(h))
+    return out
 
 
 class ScanLayer(nn.Module):
-    # requirement: submodule's return value must be the same type/shape as input
+  # requirement: submodule's return value must be the same type/shape as input
 
-    def __init__(self, submodule: nn.Module, num_layers: int):
-        super().__init__()
-        self.m = submodule
-        self.num_layers = num_layers
-        one_block_statedict = self.m.state_dict()
-        self.layer_weights_keys = list(one_block_statedict.keys())
-        stacked_weights = self._stack_layer_weights(one_block_statedict, num_layers)
-        # register those as parameters on this module
+  def __init__(self, submodule: nn.Module, num_layers: int):
+    super().__init__()
+    self.m = submodule
+    self.num_layers = num_layers
+    one_block_statedict = self.m.state_dict()
+    self.layer_weights_keys = list(one_block_statedict.keys())
+    stacked_weights = self._stack_layer_weights(one_block_statedict, num_layers)
+    # register those as parameters on this module
 
-        self.params = nn.ParameterDict(
-            {self._param_name_new(k): nn.Parameter(v) for k, v in stacked_weights.items()}
-        )
+    self.params = nn.ParameterDict({
+        self._param_name_new(k): nn.Parameter(v)
+        for k, v in stacked_weights.items()
+    })
 
+  def _stack_layer_weights(self, orig_state_dict, num_layers):
+    # Create weights such that, for every [n, m] weights
+    # becomes [k, n, m] where k is number of layer
+    # i.e. stacking layer weights together
+    temp = {}
+    for k, v in orig_state_dict.items():
+      newv = torch.stack([v for _ in range(num_layers)])
+      temp[k] = newv
+    return temp
 
-    def _stack_layer_weights(self, orig_state_dict, num_layers):
-        # Create weights such that, for every [n, m] weights
-        # becomes [k, n, m] where k is number of layer
-        # i.e. stacking layer weights together
-        temp = {}
-        for k, v in orig_state_dict.items():
-            newv = torch.stack([v for _ in range(num_layers)])
-            temp[k] = newv
-        return temp
+  def _param_name_new(self, old):
+    return "___".join(old.split("."))
 
+  def _param_name_old(self, new):
+    return ".".join(new.split("___"))
 
-    def _param_name_new(self, old):
-        return '___'.join(old.split('.'))
+  def forward(self, *args, **kwargs):
+    assert not kwargs
+    weights = {
+        k: self.params[self._param_name_new(k)] for k in self.layer_weights_keys
+    }
+    scan = interop.torch_view(jax.lax.scan)
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=[],
+        names_which_can_be_offloaded=[
+            "decoder_layer_input",
+            "query_proj",
+            "key_proj",
+            "value_proj",
+            "out_proj",
+        ],
+        offload_src="device",
+        offload_dst="pinned_host",
+    )
 
-    def _param_name_old(self, new):
-        return '.'.join(new.split('___'))
+    def eval_one_layer(args, weight):
+      # unpack args
+      h, *rest = args
+      newh = torch.func.functional_call(self.m, weight, args)
+      # next layer's input; and residual to be added to list
+      return (newh, *rest), torch.ones(1)
 
-    def forward(self, *args, **kwargs):
-        assert not kwargs
-        weights = {k: self.params[self._param_name_new(k)] for k in self.layer_weights_keys}
-        scan = interop.torch_view(jax.lax.scan)
-        policy = jax.checkpoint_policies.save_and_offload_only_these_names(
-            names_which_can_be_saved=[],
-            names_which_can_be_offloaded=[
-                "decoder_layer_input",
-                "query_proj",
-                "key_proj",
-                "value_proj",
-                "out_proj",
-            ],
-            offload_src="device",
-            offload_dst="pinned_host",
-        )
-
-        def eval_one_layer(args, weight):
-            # unpack args
-            h, *rest = args
-            newh = torch.func.functional_call(self.m, weight, args)
-            # next layer's input; and residual to be added to list
-            return (newh, *rest), torch.ones(1)
-
-        _eval_one_layer = interop.call_jax(
-            jax.checkpoint, 
-            eval_one_layer,
-            policy=policy,
-        )
-        h, _ = scan(
-            _eval_one_layer,
-            args,
-            weights,
-        )
-        return h[0]
-
-
-
+    _eval_one_layer = interop.call_jax(
+        jax.checkpoint,
+        eval_one_layer,
+        policy=policy,
+    )
+    h, _ = scan(
+        _eval_one_layer,
+        args,
+        weights,
+    )
+    return h[0]
 
 
 class Transformer(nn.Module):
-    def __init__(self, params: ModelArgs):
-        super().__init__()
-        self.params = params
-        self.vocab_size = params.vocab_size
-        self.n_layers = params.n_layers
 
-        self.tok_embeddings = nn.Embedding(
-            params.vocab_size, params.dim,
-        )
+  def __init__(self, params: ModelArgs):
+    super().__init__()
+    self.params = params
+    self.vocab_size = params.vocab_size
+    self.n_layers = params.n_layers
 
-        # self.layers = torch.nn.ModuleList()
-        # for layer_id in range(params.n_layers):
-        #     self.layers.append(TransformerBlock(layer_id, params))
-        self.layers = ScanLayer(TransformerBlock(0, params), params.n_layers)
+    self.tok_embeddings = nn.Embedding(
+        params.vocab_size,
+        params.dim,
+    )
 
-        self.norm = RMSNorm(params.dim, eps=params.norm_eps)
-        self.output = nn.Linear(
-            params.dim, params.vocab_size, bias=False,
-        )
+    # self.layers = torch.nn.ModuleList()
+    # for layer_id in range(params.n_layers):
+    #     self.layers.append(TransformerBlock(layer_id, params))
+    self.layers = ScanLayer(TransformerBlock(0, params), params.n_layers)
 
-    def forward(self, tokens: torch.Tensor, start_pos: int, freqs_cis, mask):
-        _bsz, seqlen = tokens.shape
-        h = self.tok_embeddings(tokens)
-        h = self.layers(h, start_pos, freqs_cis, mask)
-        h = self.norm(h)
-        output = self.output(h)
-        return output
+    self.norm = RMSNorm(params.dim, eps=params.norm_eps)
+    self.output = nn.Linear(
+        params.dim,
+        params.vocab_size,
+        bias=False,
+    )
+
+  def forward(self, tokens: torch.Tensor, start_pos: int, freqs_cis, mask):
+    _bsz, seqlen = tokens.shape
+    h = self.tok_embeddings(tokens)
+    h = self.layers(h, start_pos, freqs_cis, mask)
+    h = self.norm(h)
+    output = self.output(h)
+    return output

--- a/torchprime/experimental/torchax_models/run.py
+++ b/torchprime/experimental/torchax_models/run.py
@@ -1,248 +1,309 @@
 import functools
-import numpy as np
-import jax
-import jax.numpy as jnp
-from jax.sharding import PartitionSpec as P, NamedSharding
-import torch
-from llama import model, model_with_scan, model_with_collectives
-import train
-import torch_xla2
-from torch_xla2 import interop
-from torch_xla2.ops import mappings
-import custom_mesh
-from jax.sharding import Mesh
 import math
-import splash_attn
 
-from jax.experimental.mesh_utils import create_device_mesh, create_hybrid_device_mesh
-from jax.experimental.shard_map import shard_map
+import custom_mesh
+import jax
+import numpy as np
+import splash_attn
+import torch
+import torch_xla2
+import train
+from jax.experimental.mesh_utils import (
+    create_device_mesh,
+    create_hybrid_device_mesh,
+)
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from llama import model, model_with_collectives, model_with_scan
+from torch_xla2 import interop
 
 sharding_map_original = {
-  "freqs_cis" : (), #  torch.complex64 (2048, 64)
-  "tok_embeddings.weight" : ('fsdp', 'tp'), #  torch.float32 (vocab_size, 4096)
-  "layers.*.attention.wo.weight" : ('fsdp', 'tp'), #  torch.int8 (4096, 4096)
-  "layers.*.attention.wq.weight" : ('tp', 'fsdp'), #  torch.int8 (4096, 4096)
-  "layers.*.attention.wk.weight" : ('tp', 'fsdp'), #  torch.int8 (4096, 4096)
-  "layers.*.attention.wv.weight" : ('tp', 'fsdp'), #  torch.int8 (4096, 4096)
-  "layers.*.feed_forward.w1.weight" : ('tp', 'fsdp'), #  torch.float32 (11008, 4096)
-  "layers.*.feed_forward.w2.weight" : ('fsdp', 'tp'), #  torch.float32 (4096, 11008)
-  "layers.*.feed_forward.w3.weight": ('tp', 'fsdp'), #  torch.float32 (11008, 4096)
-  "layers.*.attention_norm.weight" : ('fsdp', ), #  torch.float32 (4096,)
-  "layers.*.ffn_norm.weight" : ('fsdp', ), #  torch.float32 (4096,)
-  "norm.weight" : ('fsdp', ), #  torch.float32 (4096,)
-  "output.weight" : ('tp', 'fsdp'), #  torch.float32 (vocab_size, 4096)
+    "freqs_cis": (),  #  torch.complex64 (2048, 64)
+    "tok_embeddings.weight": (
+        "fsdp",
+        "tp",
+    ),  #  torch.float32 (vocab_size, 4096)
+    "layers.*.attention.wo.weight": ("fsdp", "tp"),  #  torch.int8 (4096, 4096)
+    "layers.*.attention.wq.weight": ("tp", "fsdp"),  #  torch.int8 (4096, 4096)
+    "layers.*.attention.wk.weight": ("tp", "fsdp"),  #  torch.int8 (4096, 4096)
+    "layers.*.attention.wv.weight": ("tp", "fsdp"),  #  torch.int8 (4096, 4096)
+    "layers.*.feed_forward.w1.weight": (
+        "tp",
+        "fsdp",
+    ),  #  torch.float32 (11008, 4096)
+    "layers.*.feed_forward.w2.weight": (
+        "fsdp",
+        "tp",
+    ),  #  torch.float32 (4096, 11008)
+    "layers.*.feed_forward.w3.weight": (
+        "tp",
+        "fsdp",
+    ),  #  torch.float32 (11008, 4096)
+    "layers.*.attention_norm.weight": ("fsdp",),  #  torch.float32 (4096,)
+    "layers.*.ffn_norm.weight": ("fsdp",),  #  torch.float32 (4096,)
+    "norm.weight": ("fsdp",),  #  torch.float32 (4096,)
+    "output.weight": ("tp", "fsdp"),  #  torch.float32 (vocab_size, 4096)
 }
 
 sharding_map_scan = {
-  "freqs_cis" : (), #  torch.complex64 (2048, 64)
-  # ParallelEmbedding for llama2; VocabParallelEmbedding for 3
-  "tok_embeddings.weight" : ('tp', 'fsdp'), #  torch.float32 (vocab_size, 4096)
-  "layers.params.attention___wo___weight" : (None, 'fsdp', 'tp'), #  torch.int8 (n, 4096, 4096)
-  "layers.params.attention___wq___weight" : (None, 'tp', 'fsdp'), #  torch.int8 (n, 4096, 4096)
-  "layers.params.attention___wk___weight" : (None, 'tp', 'fsdp'), #  torch.int8 (n, 4096, 4096)
-  "layers.params.attention___wv___weight" : (None, 'tp', 'fsdp'), #  torch.int8 (n, 4096, 4096)
-  "layers.params.feed_forward___w1___weight" : (None, 'tp', 'fsdp'), #  torch.float32 (n, 11008, 4096)
-  "layers.params.feed_forward___w2___weight" : (None, 'fsdp', 'tp'), #  torch.float32 (n, 4096, 11008)
-  "layers.params.feed_forward___w3___weight": (None, 'tp', 'fsdp'), #  torch.float32 (n, 11008, 4096)
-  "layers.params.attention_norm___weight" : (None, 'fsdp', ), #  torch.float32 (n, 4096,)
-  "layers.params.ffn_norm___weight" : (None, 'fsdp', ), #  torch.float32 (n, 4096,)
-  "norm.weight" : ('fsdp', ), #  torch.float32 (4096,)
-  "output.weight" : ('tp', 'fsdp'), #  torch.float32 (vocab_size, 4096)
+    "freqs_cis": (),  #  torch.complex64 (2048, 64)
+    # ParallelEmbedding for llama2; VocabParallelEmbedding for 3
+    "tok_embeddings.weight": (
+        "tp",
+        "fsdp",
+    ),  #  torch.float32 (vocab_size, 4096)
+    "layers.params.attention___wo___weight": (
+        None,
+        "fsdp",
+        "tp",
+    ),  #  torch.int8 (n, 4096, 4096)
+    "layers.params.attention___wq___weight": (
+        None,
+        "tp",
+        "fsdp",
+    ),  #  torch.int8 (n, 4096, 4096)
+    "layers.params.attention___wk___weight": (
+        None,
+        "tp",
+        "fsdp",
+    ),  #  torch.int8 (n, 4096, 4096)
+    "layers.params.attention___wv___weight": (
+        None,
+        "tp",
+        "fsdp",
+    ),  #  torch.int8 (n, 4096, 4096)
+    "layers.params.feed_forward___w1___weight": (
+        None,
+        "tp",
+        "fsdp",
+    ),  #  torch.float32 (n, 11008, 4096)
+    "layers.params.feed_forward___w2___weight": (
+        None,
+        "fsdp",
+        "tp",
+    ),  #  torch.float32 (n, 4096, 11008)
+    "layers.params.feed_forward___w3___weight": (
+        None,
+        "tp",
+        "fsdp",
+    ),  #  torch.float32 (n, 11008, 4096)
+    "layers.params.attention_norm___weight": (
+        None,
+        "fsdp",
+    ),  #  torch.float32 (n, 4096,)
+    "layers.params.ffn_norm___weight": (
+        None,
+        "fsdp",
+    ),  #  torch.float32 (n, 4096,)
+    "norm.weight": ("fsdp",),  #  torch.float32 (4096,)
+    "output.weight": ("tp", "fsdp"),  #  torch.float32 (vocab_size, 4096)
 }
 
-
-from jax.experimental import pallas as pl
 
 def _bytes(x: jax.Array | jax.ShapeDtypeStruct) -> int:
   return math.prod(x.shape) * x.dtype.itemsize
 
 
 def _process_sharding_name(name):
-    """Replace integers in param name with *.
+  """Replace integers in param name with *.
 
-  Presumably all layers should have the same sharding.
-  """
+    Presumably all layers should have the same sharding.
+    """
 
-    def is_integer(t):
-        try:
-            int(t)
-            return True
-        # pylint: disable-next=all
-        except:  # noqa: E722
-            return False
+  def is_integer(t):
+    try:
+      int(t)
+      return True
+    # pylint: disable-next=all
+    except:  # noqa: E722
+      return False
 
-    tokens = name.split(".")
-    for i, t in enumerate(tokens):
-        if is_integer(t):
-            tokens[i] = "*"
-    return ".".join(tokens)
+  tokens = name.split(".")
+  for i, t in enumerate(tokens):
+    if is_integer(t):
+      tokens[i] = "*"
+  return ".".join(tokens)
 
 
 def register_attention(fn):
   from torch_xla2.ops import ops_registry
+
   env = torch_xla2.default_env()
   k = torch.nn.functional.scaled_dot_product_attention
   env._ops[k] = ops_registry.Operator(
-    k,
-    fn,
-    is_jax_function=False,
-    is_user_defined=True,
-    needs_env=False
-  )
-
+      k, fn, is_jax_function=False, is_user_defined=True, needs_env=False)
 
 
 def create_sharded_weights(model, mesh, sharding_map):
-    res = {}
-    for name, weight_meta in model.state_dict().items():
-        sharding_spec = sharding_map.get(_process_sharding_name(name))
-        if sharding_spec is None:
-            print('Skipping weight:', name)
-            continue
-        sharding = NamedSharding(mesh, P(*sharding_spec))
-        with jax.default_device(jax.devices('cpu')[0]):
-            weight_torch = torch.randn(
-              weight_meta.shape,
-              dtype=weight_meta.dtype)
-            weight_jax = torch_xla2.default_env().to_xla(weight_torch).jax()
-        #print(name, weight.shape, weight.dtype)
-        res[name] = jax.make_array_from_callback(
-          weight_jax.shape, sharding, lambda a: weight_jax[a]
-        )
-    return res
+  res = {}
+  for name, weight_meta in model.state_dict().items():
+    sharding_spec = sharding_map.get(_process_sharding_name(name))
+    if sharding_spec is None:
+      print("Skipping weight:", name)
+      continue
+    sharding = NamedSharding(mesh, P(*sharding_spec))
+    with jax.default_device(jax.devices("cpu")[0]):
+      weight_torch = torch.randn(weight_meta.shape, dtype=weight_meta.dtype)
+      weight_jax = torch_xla2.default_env().to_xla(weight_torch).jax()
+    callback = (lambda weight_jax: lambda a: weight_jax[a])(weight_jax)
+    res[name] = jax.make_array_from_callback(weight_jax.shape, sharding,
+                                             callback)
+  return res
+
 
 def sharded_device_put(tensor, sharding):
-    num_global_devices = jax.device_count()
-    num_local_devices = jax.local_device_count()
-    if isinstance(tensor, tuple):
-        return tuple(sharded_device_put(t, sharding) for t in tensor)
+  num_global_devices = jax.device_count()
+  num_local_devices = jax.local_device_count()
+  if isinstance(tensor, tuple):
+    return tuple(sharded_device_put(t, sharding) for t in tensor)
 
-    if num_global_devices == num_local_devices:
-        return jax.device_put(tensor, sharding)
+  if num_global_devices == num_local_devices:
+    return jax.device_put(tensor, sharding)
 
-    shape = tensor.shape
-    x_split = [jax.device_put(tensor[i], device) for device, i in sharding.addressable_devices_indices_map(shape).items()]
-    return jax.make_array_from_single_device_arrays(shape, sharding, x_split)
-
+  shape = tensor.shape
+  x_split = [
+      jax.device_put(tensor[i], device)
+      for device, i in sharding.addressable_devices_indices_map(shape).items()
+  ]
+  return jax.make_array_from_single_device_arrays(shape, sharding, x_split)
 
 
 def main(
-  batch_size: int = 64,
-  model_type: str='8B',
-  lr: float=0.001,
-  tp: int=4,
-  seqlen: int = 2048,
-  model_impl: str = 'scan',
-  use_custom_mesh: bool = False,
-  use_custom_offload: bool = True,
-  internal_override_layers: int = -1,
-  profile_dir: str = 'profile/',
-  unroll_layers: int = 1,
+    batch_size: int = 64,
+    model_type: str = "8B",
+    lr: float = 0.001,
+    tp: int = 4,
+    seqlen: int = 2048,
+    model_impl: str = "scan",
+    use_custom_mesh: bool = False,
+    use_custom_offload: bool = True,
+    internal_override_layers: int = -1,
+    profile_dir: str = "profile/",
+    unroll_layers: int = 1,
 ):
+  print(locals())
+  torch.manual_seed(0)
+  torch.set_default_dtype(torch.bfloat16)
+  torch_xla2.enable_performance_mode()
 
-    print(locals())
-    torch.manual_seed(0)
-    torch.set_default_dtype(torch.bfloat16)
-    torch_xla2.enable_performance_mode()
+  print("Local devices:", jax.local_device_count())
+  fsdp_size = len(jax.devices()) // tp
 
-    print('Local devices:', jax.local_device_count())
-    fsdp_size = len(jax.devices()) // tp
+  env = torch_xla2.default_env()
+  env.config.use_torch_native_for_cpu_tensor = False
 
-    env = torch_xla2.default_env()
-    env.config.use_torch_native_for_cpu_tensor = False
-
-    if use_custom_mesh:
-      tp = 4
-      if len(jax.devices()) == 512:
-        dev_array = custom_mesh.create_custom_64x4_device_mesh(
-          (64, 4), (2, 1), jax.devices()
-        )
-      else:
-        assert len(jax.devices()) == 256
-        dev_array = np.array(jax.devices()).reshape(8, 2, 8, 2).transpose(0, 2, 1, 3).reshape(64, 4)
+  if use_custom_mesh:
+    tp = 4
+    if len(jax.devices()) == 512:
+      dev_array = custom_mesh.create_custom_64x4_device_mesh((64, 4), (2, 1),
+                                                             jax.devices())
     else:
-      if fsdp_size * tp <= 256:
-          dev_array = create_device_mesh((fsdp_size, tp), allow_split_physical_axes=True)
-      else:
-          num_pod = len(jax.devices()) // 256
-          dev_array = create_hybrid_device_mesh((fsdp_size // num_pod, tp), (num_pod, 1), jax.devices())
-    mesh = Mesh(dev_array, ('fsdp', 'tp'))
-
-    if use_custom_offload:
-      policy = jax.checkpoint_policies.save_and_offload_only_these_names(
-          names_which_can_be_saved=[],
-          names_which_can_be_offloaded=[
-              "decoder_layer_input",
-              "query_proj",
-              "key_proj",
-              "value_proj",
-              "out_proj",
-          ],
-          offload_src="device",
-          offload_dst="pinned_host",
-      )
+      assert len(jax.devices()) == 256
+      dev_array = (
+          np.array(jax.devices()).reshape(8, 2, 8,
+                                          2).transpose(0, 2, 1,
+                                                       3).reshape(64, 4))
+  else:
+    if fsdp_size * tp <= 256:
+      dev_array = create_device_mesh((fsdp_size, tp),
+                                     allow_split_physical_axes=True)
     else:
-      policy=jax.checkpoint_policies.nothing_saveable
+      num_pod = len(jax.devices()) // 256
+      dev_array = create_hybrid_device_mesh((fsdp_size // num_pod, tp),
+                                            (num_pod, 1), jax.devices())
+  mesh = Mesh(dev_array, ("fsdp", "tp"))
 
-    args = model.ModelArgs(
-      **model.transformer_configs[model_type]
+  if use_custom_offload:
+    policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+        names_which_can_be_saved=[],
+        names_which_can_be_offloaded=[
+            "decoder_layer_input",
+            "query_proj",
+            "key_proj",
+            "value_proj",
+            "out_proj",
+        ],
+        offload_src="device",
+        offload_dst="pinned_host",
     )
-    if internal_override_layers > 0:
-      args.n_layers = internal_override_layers
+  else:
+    policy = jax.checkpoint_policies.nothing_saveable
 
-    with torch.device('meta'):
-        if model_impl == 'scan':
-            sharding_map = sharding_map_scan
-            llama = model_with_scan.Transformer(args)
-        elif model_impl == 'scan_manual':
-            args.tp_size = tp
-            sharding_map = sharding_map_scan
-            llama = model_with_collectives.Transformer(args, unroll_layers)
-        elif model_impl == 'orig':
-            sharding_map = sharding_map_original
-            llama = model.Transformer(args)
-        else:
-          raise AssertionError('unknown impl: ' + model_impl)
+  args = model.ModelArgs(**model.transformer_configs[model_type])
+  if internal_override_layers > 0:
+    args.n_layers = internal_override_layers
 
-    sharded_weights = create_sharded_weights(llama, mesh, sharding_map)
-    with torch.device('cpu'):
-        freqs_cis = model.precompute_freqs_cis(
-            args.dim // args.n_heads,
-            args.max_seq_len * 2,
-            args.rope_theta,
-            args.use_scaled_rope,
-        ).numpy()
-    sharding = NamedSharding(mesh, P()) # replicated
+  with torch.device("meta"):
+    if model_impl == "scan":
+      sharding_map = sharding_map_scan
+      llama = model_with_scan.Transformer(args)
+    elif model_impl == "scan_manual":
+      args.tp_size = tp
+      sharding_map = sharding_map_scan
+      llama = model_with_collectives.Transformer(args, unroll_layers)
+    elif model_impl == "orig":
+      sharding_map = sharding_map_original
+      llama = model.Transformer(args)
+    else:
+      raise AssertionError("unknown impl: " + model_impl)
 
-    env = torch_xla2.default_env()
-    freqs_cis = env.j2t_iso(jax.device_put(freqs_cis, sharding))
+  sharded_weights = create_sharded_weights(llama, mesh, sharding_map)
+  with torch.device("cpu"):
+    freqs_cis = model.precompute_freqs_cis(
+        args.dim // args.n_heads,
+        args.max_seq_len * 2,
+        args.rope_theta,
+        args.use_scaled_rope,
+    ).numpy()
+  sharding = NamedSharding(mesh, P())  # replicated
+
+  env = torch_xla2.default_env()
+  freqs_cis = env.j2t_iso(jax.device_put(freqs_cis, sharding))
+
+  # NOTE: overriding attention to capture mesh and sharding info
+  partition = P("fsdp", "tp", None, None)
+  attention = functools.partial(
+      splash_attn.tpu_splash_attention,
+      mesh,
+      partition,
+      (model_impl != "scan_manual"),
+  )
+  attention = jax.jit(attention)
+
+  def custom_attention(
+      query,
+      key,
+      value,
+      attn_mask=None,
+      dropout_p=0.0,
+      is_causal=False,
+      scale=None,
+      enable_gqa=False,
+  ):
+    #  batch, num of head, seq, dim
+    jk, jq, jv = interop.jax_view((query, key, value))
+    res = attention(jk, jq, jv, None)
+    return interop.torch_view(res)
+
+  register_attention(custom_attention)
+
+  with mesh:
+    train.train_loop(
+        mesh,
+        llama,
+        sharded_weights,
+        None,
+        freqs_cis,
+        lr,
+        seqlen,
+        policy,
+        batch_size,
+        use_shmap=(model_impl == "scan_manual"),
+        profile_dir=profile_dir,
+    )
 
 
-    # NOTE: overriding attention to capture mesh and sharding info
-    partition = P('fsdp', 'tp', None, None)
-    attention = functools.partial(
-      splash_attn.tpu_splash_attention, 
-      mesh, partition, (model_impl != 'scan_manual'))
-    attention = jax.jit(attention)
+if __name__ == "__main__":
+  import fire
 
-    def custom_attention(
-        query, key, value, attn_mask=None,
-        dropout_p=0.0, is_causal=False,
-        scale=None, enable_gqa=False):
-                  #  batch, num of head, seq, dim
-      jk, jq, jv = interop.jax_view((query, key, value))
-      res =  attention(jk, jq, jv, None)
-      return interop.torch_view(res)
-
-    register_attention(custom_attention)
-
-    with mesh:
-      train.train_loop(
-        mesh, llama, sharded_weights, None,
-        freqs_cis, lr, seqlen, policy, batch_size, use_shmap=(model_impl == 'scan_manual'),
-        profile_dir=profile_dir)
-
-
-if __name__ == '__main__':
-    import fire
-    fire.Fire(main)
+  fire.Fire(main)

--- a/torchprime/experimental/torchax_models/splash_attn.py
+++ b/torchprime/experimental/torchax_models/splash_attn.py
@@ -1,31 +1,28 @@
-import functools
-
 import jax
-import jax.numpy as jnp
-
-from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
-from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
+from jax.experimental.pallas.ops.tpu.splash_attention import (
+    splash_attention_kernel,
+    splash_attention_mask,
+)
 from jax.experimental.shard_map import shard_map
 
 
-
 def tpu_splash_attention(
-      mesh,
-      q_sharding,
-      # Input should be of shape (batch, length, heads, kv_dim)
-      apply_shard_map,
-      query: jax.Array,
-      key: jax.Array,
-      value: jax.Array,
-      decoder_segment_ids: jax.Array | None,
-      attn_logits_soft_cap: float | None = None,
+    mesh,
+    q_sharding,
+    # Input should be of shape (batch, length, heads, kv_dim)
+    apply_shard_map,
+    query: jax.Array,
+    key: jax.Array,
+    value: jax.Array,
+    decoder_segment_ids: jax.Array | None,
+    attn_logits_soft_cap: float | None = None,
 ) -> jax.Array:
   """TPU Flash Attention."""
   if decoder_segment_ids is not None:
-    decoder_segment_ids = splash_attention_kernel.SegmentIds(decoder_segment_ids, decoder_segment_ids)
+    decoder_segment_ids = splash_attention_kernel.SegmentIds(
+        decoder_segment_ids, decoder_segment_ids)
 
-
-  print('HERE', locals())
+  print("HERE", locals())
 
   global_block_q = 1024
   global_block_kv = 512
@@ -36,9 +33,9 @@ def tpu_splash_attention(
   global_block_q_dq = 2048
   global_block_kv_dq = 512
   global_use_fused_bwd_kernel = False
-  global_q_layout = 'HEAD_DIM_MINOR'
-  global_k_layout = 'HEAD_DIM_MINOR'
-  global_v_layout = 'HEAD_DIM_MINOR'
+  global_q_layout = "HEAD_DIM_MINOR"
+  global_k_layout = "HEAD_DIM_MINOR"
+  global_v_layout = "HEAD_DIM_MINOR"
 
   def wrap_flash_attention(query, key, value, decoder_segment_ids):
     if decoder_segment_ids is not None:
@@ -52,19 +49,23 @@ def tpu_splash_attention(
         block_q_dkv=min(global_block_q_dkv, query.shape[2]),
         block_kv_dkv=min(global_block_kv_dkv, key.shape[2]),
         block_kv_dkv_compute=min(global_block_kv_dkv_compute, query.shape[2]),
-        block_q_dq=None if global_use_fused_bwd_kernel else min(global_block_q_dq, query.shape[2]),
-        block_kv_dq=None if global_use_fused_bwd_kernel else min(global_block_kv_dq, query.shape[2]),
+        block_q_dq=None if global_use_fused_bwd_kernel else min(
+            global_block_q_dq, query.shape[2]),
+        block_kv_dq=None if global_use_fused_bwd_kernel else min(
+            global_block_kv_dq, query.shape[2]),
         use_fused_bwd_kernel=global_use_fused_bwd_kernel,
         q_layout=splash_attention_kernel.QKVLayout[global_q_layout],
         k_layout=splash_attention_kernel.QKVLayout[global_k_layout],
         v_layout=splash_attention_kernel.QKVLayout[global_v_layout],
     )
 
-    mask = splash_attention_mask.CausalMask(shape=(query.shape[2], query.shape[2]))
+    mask = splash_attention_mask.CausalMask(
+        shape=(query.shape[2], query.shape[2]))
 
     # Create multi-head mask
-    multi_head_mask = splash_attention_mask.MultiHeadMask(masks=(mask,) * query.shape[1])
-    #splash_kernel = splash_attention_kernel.make_splash_mha(
+    multi_head_mask = splash_attention_mask.MultiHeadMask(
+        masks=(mask,) * query.shape[1])
+    # splash_kernel = splash_attention_kernel.make_splash_mha(
     splash_kernel = splash_attention_kernel.make_splash_mha(
         mask=multi_head_mask,
         head_shards=1,
@@ -73,25 +74,22 @@ def tpu_splash_attention(
         attn_logits_soft_cap=attn_logits_soft_cap,
     )
 
-    return jax.vmap(splash_kernel)(query, key, value, segment_ids=decoder_segment_ids)
+    return jax.vmap(splash_kernel)(
+        query, key, value, segment_ids=decoder_segment_ids)
 
   if apply_shard_map:
     wrap_flash_attention = shard_map(
-      wrap_flash_attention,
-      mesh=mesh,
-      in_specs=(
-          q_sharding,
-          q_sharding,
-          q_sharding,
-          None,
-      ),
-      out_specs=q_sharding,
-      check_rep=False,
+        wrap_flash_attention,
+        mesh=mesh,
+        in_specs=(
+            q_sharding,
+            q_sharding,
+            q_sharding,
+            None,
+        ),
+        out_specs=q_sharding,
+        check_rep=False,
     )
 
   x = wrap_flash_attention(query, key, value, decoder_segment_ids)
   return x
-
-
-if __name__ == '__main__':
-  main()

--- a/torchprime/experimental/torchax_models/train.py
+++ b/torchprime/experimental/torchax_models/train.py
@@ -1,14 +1,17 @@
 # Utilities for training
+import copy
 import functools
 import time
+
+import jax
+import optax
 import torch
 import torch_xla2
-from torch_xla2 import interop
-import optax
-import jax
-from jax.sharding import PartitionSpec as P, NamedSharding
-from jax.tree_util import tree_map
 from jax.experimental import shard_map
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import tree_map
+from torch_xla2 import interop
 
 SEQLEN = 2048
 
@@ -17,6 +20,7 @@ SEQLEN = 2048
 
 ## Interface for loss_fn:
 ## loss_fn(model_out, label) -> scalar
+
 
 class TraininableLlama:
 
@@ -27,130 +31,138 @@ class TraininableLlama:
   def call(self, weights, buffers, args, kwargs):
     weights_and_buffers = copy.copy(weights)
     weights_and_buffers.update(buffers)
-    return torch.func.call_functional(
-      self.orig_model, weights_and_buffers, args, kwargs)
-
-
+    return torch.func.call_functional(self.orig_model, weights_and_buffers,
+                                      args, kwargs)
 
 
 def fake_dataloader(size, seqlen, batch_size):
   for _ in range(size):
-    x = torch.randint(0, 32000, (batch_size, seqlen), device='cpu')
+    x = torch.randint(0, 32000, (batch_size, seqlen), device="cpu")
     yield x, (x + 1) % 32000
 
+
 def group_data(dataloader, block_size):
-    """yields tuple of inputs, label with seqlen == block_size"""
+  """yields tuple of inputs, label with seqlen == block_size"""
 
-    tally = 0
-    inputs = []
-    labels = []
+  tally = 0
+  inputs = []
+  labels = []
 
-    for line in dataloader:
-        x, y = line #line['input_ids'], line['labels']
-        inputs.append(x)
-        labels.append(y)
-        seqlen = x.shape[1]
-        tally += seqlen
-        if tally >= block_size:
-            inputs_stacked = torch.concat(inputs, dim=-1)
-            labels_stacked = torch.concat(labels, dim=-1)
-            yield inputs_stacked, labels_stacked
-            tally = 0
-            inputs = []
-            labels = []
+  for line in dataloader:
+    x, y = line  # line['input_ids'], line['labels']
+    inputs.append(x)
+    labels.append(y)
+    seqlen = x.shape[1]
+    tally += seqlen
+    if tally >= block_size:
+      inputs_stacked = torch.concat(inputs, dim=-1)
+      labels_stacked = torch.concat(labels, dim=-1)
+      yield inputs_stacked, labels_stacked
+      tally = 0
+      inputs = []
+      labels = []
 
 
 def sharded_device_put(tensor, sharding):
-    if isinstance(tensor, tuple):
-        return tuple(sharded_device_put(t, sharding) for t in tensor)
-    num_global_devices = jax.device_count()
-    num_local_devices = jax.local_device_count()
+  if isinstance(tensor, tuple):
+    return tuple(sharded_device_put(t, sharding) for t in tensor)
+  num_global_devices = jax.device_count()
+  num_local_devices = jax.local_device_count()
 
-    if num_global_devices == num_local_devices:
-        return jax.device_put(tensor, sharding)
+  if num_global_devices == num_local_devices:
+    return jax.device_put(tensor, sharding)
 
-    shape = tensor.shape
-    x_split = [jax.device_put(tensor[i], device) for device, i in sharding.addressable_devices_indices_map(shape).items()]
-    return jax.make_array_from_single_device_arrays(shape, sharding, x_split)
+  shape = tensor.shape
+  x_split = [
+      jax.device_put(tensor[i], device)
+      for device, i in sharding.addressable_devices_indices_map(shape).items()
+  ]
+  return jax.make_array_from_single_device_arrays(shape, sharding, x_split)
 
 
 # NOTE: this line makes jax.remat able to take torch functions
 remat = interop.torch_view(jax.remat)
 mark_sharding = interop.torch_view(jax.lax.with_sharding_constraint)
 
-def make_train_step(model_forward, loss_fn, optax_optimizer, policy):
 
+def make_train_step(model_forward, loss_fn, optax_optimizer, policy):
   env = torch_xla2.default_env()
 
-  @functools.partial(
-    remat,
-    policy=policy)
-  def loss(weights, args, label): # inputs are XLATensor
-    with env, jax.named_scope('compute_loss'):
-      args = (mark_sharding(args[0], P('fsdp')), *args[1:])
+  @functools.partial(remat, policy=policy)
+  def loss(weights, args, label):  # inputs are XLATensor
+    with env, jax.named_scope("compute_loss"):
+      args = (mark_sharding(args[0], P("fsdp")), *args[1:])
       res = model_forward(weights, args)
-      res = mark_sharding(res, P('fsdp'))
+      res = mark_sharding(res, P("fsdp"))
       num_tokens = res.shape[-1]
       flattened = res.reshape(-1, num_tokens)
       label = label.reshape(-1)
-      l = loss_fn(flattened, label)
-      return l
+      loss = loss_fn(flattened, label)
+      return loss
 
   jloss = interop.jax_view(loss)
   grad_fn = jax.value_and_grad(jloss)
 
-  def step(weights, opt_state, args, label): #inputs are array
-    with jax.named_scope('compute_gradient'):
-        loss, gradient = grad_fn(weights, args, label)
+  def step(weights, opt_state, args, label):  # inputs are array
+    with jax.named_scope("compute_gradient"):
+      loss, gradient = grad_fn(weights, args, label)
 
     with jax.named_scope("optimizer_updates"):
-        updates, opt_state = optax_optimizer.update(
-            gradient, opt_state, weights)
-        weights = optax.apply_updates(weights, updates)
+      updates, opt_state = optax_optimizer.update(gradient, opt_state, weights)
+      weights = optax.apply_updates(weights, updates)
     return loss, weights, opt_state
 
   return step
 
-def _prelower_step(step, weights, opt_state, args, label, mesh):
-  wshardings = tree_map(lambda a: a.sharding if isinstance(a, jax.Array) else None,
-                       weights)
-  oshardings = tree_map(lambda a: a.sharding if isinstance(a, jax.Array) else None,
-                       opt_state)
 
-  print('Start compiling')
+def _prelower_step(step, weights, opt_state, args, label, mesh):
+  wshardings = tree_map(
+      lambda a: a.sharding if isinstance(a, jax.Array) else None, weights)
+  oshardings = tree_map(
+      lambda a: a.sharding if isinstance(a, jax.Array) else None, opt_state)
+
+  print("Start compiling")
   start = time.perf_counter()
   lowered = jax.jit(
-    step,
-    donate_argnums=(0, 1),
-    #in_shardings=shardings,
-    out_shardings=(NamedSharding(mesh, P()), wshardings, oshardings),
-  ).lower(
-      weights, opt_state, args, label
-  )
-  #print(lowered.as_text())
+      step,
+      donate_argnums=(0, 1),
+      # in_shardings=shardings,
+      out_shardings=(NamedSharding(mesh, P()), wshardings, oshardings),
+  ).lower(weights, opt_state, args, label)
+  # print(lowered.as_text())
   # import pdb; pdb.set_trace()
-  print('program size:', len(lowered.as_text()) / 1e6, 'm chars')
-  step_compiled  = lowered.compile()
+  print("program size:", len(lowered.as_text()) / 1e6, "m chars")
+  step_compiled = lowered.compile()
   end = time.perf_counter()
-  print('End compiling', end - start)
+  print("End compiling", end - start)
   compile_time = end - start
+  print("Compile time:", compile_time)
   for co in step_compiled.cost_analysis():
-      print('Flops', co['flops'])
-      print('GB accessed', co['bytes accessed'] / 1e9)
+    print("Flops", co["flops"])
+    print("GB accessed", co["bytes accessed"] / 1e9)
   return step_compiled
 
-from optax import ScaleByAdamState
 
-
-def train_loop(mesh, model, weights, data_loader,
-    input_freqs_cis, lr, seqlen, policy, batch_size, use_shmap, profile_dir: str):
-  print('start training')
+def train_loop(
+    mesh,
+    model,
+    weights,
+    data_loader,
+    input_freqs_cis,
+    lr,
+    seqlen,
+    policy,
+    batch_size,
+    use_shmap,
+    profile_dir: str,
+):
+  print("start training")
   min_loop_time = 10000
 
   env = torch_xla2.default_env()
 
   jax_params = env.t2j_iso(weights)
-  #jax_optimizer = optax.adamw(lr)
+  # jax_optimizer = optax.adamw(lr)
   jax_optimizer = optax.sgd(lr)
   opt_state = jax_optimizer.init(jax_params)
   # opt_state = (ScaleByAdamState(
@@ -161,32 +173,29 @@ def train_loop(mesh, model, weights, data_loader,
   # ), *opt_state[1:])
 
   wspecs = tree_map(lambda a: a.sharding.spec, jax_params)
-  waxis = tree_map(lambda a: a.index('fsdp'), wspecs)
-
 
   model_forward_orig = functools.partial(torch.func.functional_call, model)
 
   @functools.partial(
-    shard_map.shard_map,
-    mesh=mesh,
-    in_specs=(
-      wspecs,
-      (P('fsdp'), P(), P(), P())
-    ),
-    out_specs=(P('fsdp')),
-    check_rep=False
+      shard_map.shard_map,
+      mesh=mesh,
+      in_specs=(wspecs, (P("fsdp"), P(), P(), P())),
+      out_specs=(P("fsdp")),
+      check_rep=False,
   )
   def model_forward_shmap(weight, args):
+
     def gather_weights(w, spec):
       try:
-        index = spec.index('fsdp')
-        w = jax.lax.all_gather(w, axis_name='fsdp', tiled=True, axis=index)
+        index = spec.index("fsdp")
+        w = jax.lax.all_gather(w, axis_name="fsdp", tiled=True, axis=index)
         return w
       except ValueError:
         return w
+
     new_weights = {}
     for k, v in weight.items():
-      if not k.startswith('layers'):
+      if not k.startswith("layers"):
         new_weights[k] = gather_weights(v, wspecs[k])
       else:
         new_weights[k] = v
@@ -199,63 +208,62 @@ def train_loop(mesh, model, weights, data_loader,
   else:
     model_forward = model_forward_orig
 
-  train_step = make_train_step(model_forward,
-    loss_fn=torch.nn.CrossEntropyLoss(),
-    optax_optimizer=jax_optimizer,
-    policy=policy,
+  train_step = make_train_step(
+      model_forward,
+      loss_fn=torch.nn.CrossEntropyLoss(),
+      optax_optimizer=jax_optimizer,
+      policy=policy,
   )
 
   def _expand_input(input_seq):
     seqlen = input_seq.shape[1]
     freqs_cis = env.t2j_iso(input_freqs_cis[:seqlen])
-    mask = torch.full((seqlen, seqlen), float("-inf"), device='cpu')
+    mask = torch.full((seqlen, seqlen), float("-inf"), device="cpu")
     mask = torch.triu(mask, diagonal=1)
     return (input_seq, 0, freqs_cis, mask)
 
   replicated_sharding = NamedSharding(mesh, P())
-  fsdp_sharding = NamedSharding(mesh, P('fsdp'))
+  fsdp_sharding = NamedSharding(mesh, P("fsdp"))
+
   def _shard_first_dim(x):
-    with jax.default_device(jax.devices('cpu')[0]):
+    with jax.default_device(jax.devices("cpu")[0]):
       xj = env.to_xla(x).jax()
 
-    new_shape = list(xj.shape)
-    xj = jax.make_array_from_callback(
-      xj.shape, fsdp_sharding, lambda a: xj[a]
-    )
+    xj = jax.make_array_from_callback(xj.shape, fsdp_sharding, lambda a: xj[a])
     return xj
 
   def _replicate(x):
-    with jax.default_device(jax.devices('cpu')[0]):
+    with jax.default_device(jax.devices("cpu")[0]):
       xj = env.to_xla(x).jax()
-    xj = jax.make_array_from_callback(
-      xj.shape, replicated_sharding, lambda a: xj
-    )
+    xj = jax.make_array_from_callback(xj.shape, replicated_sharding,
+                                      lambda a: xj)
     return xj
 
   data_iter = fake_dataloader(1000, seqlen, batch_size)
 
-
   for i, item in enumerate(data_iter):
-    with jax.profiler.StepTraceAnnotation('train', step_num=i):
+    with jax.profiler.StepTraceAnnotation("train", step_num=i):
       inputs, labels = item
 
       input_seq, pos, freqs_cis, mask = _expand_input(inputs)
-
 
       input_seq = _shard_first_dim(input_seq)
       freqs_cis = freqs_cis
       mask = _replicate(mask)
       labels = _shard_first_dim(labels)
 
-      print('INPUT shape', inputs.shape)
+      print("INPUT shape", inputs.shape)
       if i == 0:
         # NOTE: this is not necessary; but I want to print out
         # Stablehlo, and compile times
         train_step = _prelower_step(
-          train_step, jax_params, opt_state,
-          (input_seq, pos, freqs_cis, mask), labels, mesh)
-
-        
+            train_step,
+            jax_params,
+            opt_state,
+            (input_seq, pos, freqs_cis, mask),
+            labels,
+            mesh,
+        )
 
       if i == 5:
         jax.profiler.start_trace(profile_dir)
@@ -267,12 +275,17 @@ def train_loop(mesh, model, weights, data_loader,
       if i == 6:
         jax.profiler.stop_trace()
 
-      print(i, 'loss', loss, loss.dtype, 'step latency: ', step_end - step_start)
-      min_loop_time =  min(min_loop_time, step_end - step_start)
-      print('======')
+      print(
+          i,
+          "loss",
+          loss,
+          loss.dtype,
+          "step latency: ",
+          step_end - step_start,
+      )
+      min_loop_time = min(min_loop_time, step_end - step_start)
+      print("======")
       if i >= 6:
-          break
+        break
 
   return min_loop_time
-
-

--- a/torchprime/torch_xla_models/llama/__init__.py
+++ b/torchprime/torch_xla_models/llama/__init__.py
@@ -1,1 +1,3 @@
 from .model import LlamaForCausalLM
+
+__all__ = ['LlamaForCausalLM']

--- a/torchprime/torch_xla_models/tests/test_llama.py
+++ b/torchprime/torch_xla_models/tests/test_llama.py
@@ -1,45 +1,52 @@
 import unittest
 
-from transformers import AutoConfig, LlamaForCausalLM as HfLlamaForCausalLM
-
 import torch
 import torch_xla
+from transformers import AutoConfig
+from transformers import LlamaForCausalLM as HfLlamaForCausalLM
 
 from torchprime.torch_xla_models.llama import LlamaForCausalLM
 
 
 class TestYourModule(unittest.TestCase):
-    def test_forward(self):
-        config = AutoConfig.from_pretrained(
-            "meta-llama/Meta-Llama-3-8B",
-            num_hidden_layers=1,
-            num_attention_heads=8,
-            hidden_size=8,
-            intermediate_size=16,
-            vocab_size=128,
-        )
-        config.flash_attention = False
 
-        device = torch_xla.device()
-        torch.manual_seed(42)
-        torch_xla.manual_seed(42)
-        with device:
-            hf_model = HfLlamaForCausalLM(config)
-            model = LlamaForCausalLM(config)
-            model.load_state_dict(hf_model.state_dict())
-        torch_xla.sync()
+  def test_forward(self):
+    config = AutoConfig.from_pretrained(
+        "meta-llama/Meta-Llama-3-8B",
+        num_hidden_layers=1,
+        num_attention_heads=8,
+        hidden_size=8,
+        intermediate_size=16,
+        vocab_size=128,
+    )
+    config.flash_attention = False
 
-        input_sizes = [8, 128, 256]
-        for input_size in input_sizes:
-            input = torch.randint(128, ((2, input_size // 2))).to(device)
-            hf_output = hf_model(input, labels=input, attention_mask=torch.ones_like(input))
-            llama_output = model(input, labels=input, attention_mask=torch.ones_like(input))
-            torch_xla.sync()
-            self.assertTrue(torch.allclose(hf_output.logits, llama_output.logits, atol=1e-6),
-                            "logits are not equal")
-            self.assertTrue(torch.allclose(hf_output.loss, llama_output.loss, atol=1e-6),
-                            "loss is not equal")
+    device = torch_xla.device()
+    torch.manual_seed(42)
+    torch_xla.manual_seed(42)
+    with device:
+      hf_model = HfLlamaForCausalLM(config)
+      model = LlamaForCausalLM(config)
+      model.load_state_dict(hf_model.state_dict())
+    torch_xla.sync()
+
+    input_sizes = [8, 128, 256]
+    for input_size in input_sizes:
+      input = torch.randint(128, ((2, input_size // 2))).to(device)
+      hf_output = hf_model(
+          input, labels=input, attention_mask=torch.ones_like(input))
+      llama_output = model(
+          input, labels=input, attention_mask=torch.ones_like(input))
+      torch_xla.sync()
+      self.assertTrue(
+          torch.allclose(hf_output.logits, llama_output.logits, atol=1e-6),
+          "logits are not equal",
+      )
+      self.assertTrue(
+          torch.allclose(hf_output.loss, llama_output.loss, atol=1e-6),
+          "loss is not equal",
+      )
 
 
-if __name__ == '__main__':
-    unittest.main()
+if __name__ == "__main__":
+  unittest.main()

--- a/torchprime/torch_xla_models/train.py
+++ b/torchprime/torch_xla_models/train.py
@@ -5,17 +5,11 @@ import os
 import sys
 from dataclasses import dataclass, field
 from timeit import default_timer as timer
-from typing import Optional, Union
 
 # Third-party library imports
 import datasets
 import numpy as np
 import torch
-import transformers
-from datasets import load_dataset
-from torch import nn
-from torch.optim import AdamW
-from torch.utils.data import DataLoader, Dataset, IterableDataset
 
 # PyTorch XLA imports
 import torch_xla.core.xla_model as xm
@@ -23,9 +17,16 @@ import torch_xla.debug.profiler as xp
 import torch_xla.distributed.parallel_loader as pl
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+import transformers
+from datasets import load_dataset
+from torch import nn
+from torch.optim import AdamW
+from torch.utils.data import DataLoader, Dataset, IterableDataset
 from torch_xla.distributed.fsdp import checkpoint_module
 from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
-from torch_xla.experimental.spmd_fully_sharded_data_parallel import SpmdFullyShardedDataParallel as FSDPv2
+from torch_xla.experimental.spmd_fully_sharded_data_parallel import (
+    SpmdFullyShardedDataParallel as FSDPv2,
+)  # yapf: disable
 
 # Transformers imports
 from transformers import (
@@ -39,7 +40,6 @@ from transformers import (
 )
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.trainer_pt_utils import get_module_class_from_name
-from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version
 
 # TorchPrime imports
@@ -54,346 +54,359 @@ assert xr.is_spmd() is True
 
 @dataclass
 class ModelArguments:
-    """
-    Arguments pertaining to which model/config/tokenizer we are going to fine-tune, or train from scratch.
-    """
+  """
+  Arguments pertaining to which model/config/tokenizer we are going to fine-tune,
+  or train from scratch.
+  """
 
-    model_id: Optional[str] = field(
-        default="meta-llama/Llama-2-7b-hf",
-        metadata={
-            "help":
-            "Pretrained config name or path if not the same as model_name"
-        })
-    tokenizer_name: Optional[str] = field(
-        default=None,
-        metadata={"help": "Name of the tokenizer if different from model_id"})
-    cache_dir: Optional[str] = field(
-        default=None,
-        metadata={
-            "help":
-            "Where do you want to store the pretrained models downloaded from huggingface.co"
-        },
-    )
+  model_id: str | None = field(
+      default="meta-llama/Llama-2-7b-hf",
+      metadata={
+          "help": "Pretrained config name or path if not the same as model_name"
+      },
+  )
+  tokenizer_name: str | None = field(
+      default=None,
+      metadata={"help": "Name of the tokenizer if different from model_id"},
+  )
+  cache_dir: str | None = field(
+      default=None,
+      metadata={
+          "help":
+              "Where do you want to store the pretrained models downloaded from huggingface.co"
+      },
+  )
 
 
 @dataclass
 class MoreTrainingArguments(TrainingArguments):
-    profile_step: Optional[int] = field(default=-1,
-                                        metadata={"help": "Step to profile"})
-    profile_dir: Optional[str] = field(
-        default="profile/", metadata={"help": "Directory to store the profile"})
-    profile_duration: Optional[int] = field(
-        default=20000, metadata={"help": "Duration (ms) to capture profile"})
-    global_batch_size: Optional[int] = field(
-        default=None, metadata={"help": "Global batch size"})
+  profile_step: int | None = field(
+      default=-1, metadata={"help": "Step to profile"})
+  profile_dir: str | None = field(
+      default="profile/", metadata={"help": "Directory to store the profile"})
+  profile_duration: int | None = field(
+      default=20000, metadata={"help": "Duration (ms) to capture profile"})
+  global_batch_size: int | None = field(
+      default=None, metadata={"help": "Global batch size"})
 
 
 @dataclass
 class DataTrainingArguments:
-    """
-    Arguments pertaining to what data we are going to input our model for training.
-    """
+  """
+  Arguments pertaining to what data we are going to input our model for training.
+  """
 
-    dataset_name: Optional[str] = field(
-        default=None,
-        metadata={
-            "help":
-            "The name of the dataset to use (via the datasets library)."
-        })
-    dataset_config_name: Optional[str] = field(
-        default=None,
-        metadata={
-            "help":
-            "The configuration name of the dataset to use (via the datasets library)."
-        })
-    block_size: Optional[int] = field(
-        default=None,
-        metadata={
-            "help":
-            ("Optional input sequence length after tokenization. "
-             "The training dataset will be truncated in block of this size for training. "
-             "Default to the model max input length for single sentence inputs (take into account special tokens)."
-             )
-        },
-    )
+  dataset_name: str | None = field(
+      default=None,
+      metadata={
+          "help": "The name of the dataset to use (via the datasets library)."
+      },
+  )
+  dataset_config_name: str | None = field(
+      default=None,
+      metadata={
+          "help":
+              "The configuration name of the dataset to use (via the datasets library)."
+      },
+  )
+  block_size: int | None = field(
+      default=None,
+      metadata={
+          "help": (
+              "Optional input sequence length after tokenization. "
+              "The training dataset will be truncated in block of this size for training. "
+              "Default to the model max input length for single sentence inputs (take into account special tokens)."
+          )
+      },
+  )
 
-    def __post_init__(self):
-        if self.dataset_name is None and self.train_file is None and self.validation_file is None:
-            raise ValueError(
-                "Need either a dataset name or a training/validation file.")
+  def __post_init__(self):
+    if (self.dataset_name is None and self.train_file is None and
+        self.validation_file is None):
+      raise ValueError(
+          "Need either a dataset name or a training/validation file.")
 
 
 class Trainer:
-    """The trainer."""
-    def __init__(
-        self,
-        model: nn.Module,
-        args: MoreTrainingArguments,
-        train_dataset: Optional[Union[Dataset, IterableDataset]],
-    ):
-        self.args = args
-        self.device = xm.xla_device()
-        self.global_batch_size = args.global_batch_size
-        self.train_dataset = train_dataset
+  """The trainer."""
 
-        # Set up SPMD mesh and shard the model
-        num_devices = xr.global_runtime_device_count()
-        xs.set_global_mesh(
-            xs.Mesh(np.array(range(num_devices)), (num_devices, 1),
-                    axis_names=("fsdp", "tensor")))
-        logger.info(f"Logical mesh shape: {xs.get_global_mesh().shape()}")
-        self.input_sharding_spec = xs.ShardingSpec(xs.get_global_mesh(),
-                                                   ("fsdp", None),
-                                                   minibatch=True)
-        self.model = self._shard_model(model)
+  def __init__(
+      self,
+      model: nn.Module,
+      args: MoreTrainingArguments,
+      train_dataset: Dataset | IterableDataset | None,
+  ):
+    self.args = args
+    self.device = xm.xla_device()
+    self.global_batch_size = args.global_batch_size
+    self.train_dataset = train_dataset
 
-        # Set up optimizers
-        self.optimizer = AdamW(params=model.parameters(),
-                               lr=args.learning_rate,
-                               betas=(args.adam_beta1, args.adam_beta2),
-                               eps=args.adam_epsilon)
+    # Set up SPMD mesh and shard the model
+    num_devices = xr.global_runtime_device_count()
+    xs.set_global_mesh(
+        xs.Mesh(
+            np.array(range(num_devices)),
+            (num_devices, 1),
+            axis_names=("fsdp", "tensor"),
+        ))
+    logger.info(f"Logical mesh shape: {xs.get_global_mesh().shape()}")
+    self.input_sharding_spec = xs.ShardingSpec(
+        xs.get_global_mesh(), ("fsdp", None), minibatch=True)
+    self.model = self._shard_model(model)
 
-        # TODO: this OOMs the TPU.
-        # self._prime_optimizer()
+    # Set up optimizers
+    self.optimizer = AdamW(
+        params=model.parameters(),
+        lr=args.learning_rate,
+        betas=(args.adam_beta1, args.adam_beta2),
+        eps=args.adam_epsilon,
+    )
 
-        self.lr_scheduler = get_scheduler(name=args.lr_scheduler_type,
-                                          optimizer=self.optimizer,
-                                          num_warmup_steps=args.warmup_steps,
-                                          num_training_steps=args.max_steps)
+    # TODO: this OOMs the TPU.
+    # self._prime_optimizer()
 
-    def _prime_optimizer(self):
-        for group in self.optimizer.param_groups:
-            for p in group['params']:
-                p.grad = torch.zeros_like(p)
-                p.grad.requires_grad_(False)
-        self.optimizer.step()
-        xm.mark_step()
+    self.lr_scheduler = get_scheduler(
+        name=args.lr_scheduler_type,
+        optimizer=self.optimizer,
+        num_warmup_steps=args.warmup_steps,
+        num_training_steps=args.max_steps,
+    )
 
-    def _get_train_dataloader(self):
-        if self.train_dataset is None:
-            raise ValueError("Trainer: training requires a train_dataset.")
+  def _prime_optimizer(self):
+    for group in self.optimizer.param_groups:
+      for p in group["params"]:
+        p.grad = torch.zeros_like(p)
+        p.grad.requires_grad_(False)
+    self.optimizer.step()
+    xm.mark_step()
 
-        num_replicas = xr.process_count()
-        logger.info(f"Num replicas: {num_replicas}")
-        sampler = torch.utils.data.DistributedSampler(
-            self.train_dataset,
-            num_replicas=num_replicas,
-            rank=xr.process_index())
-        assert self.global_batch_size is not None
-        dataloader = DataLoader(
-            self.train_dataset,
-            # Data collator will default to DataCollatorWithPadding, so we change it.
-            collate_fn=default_data_collator,
-            # This is the host batch size.
-            batch_size=self.global_batch_size // num_replicas,
-            sampler=sampler,
-            drop_last=True,
+  def _get_train_dataloader(self):
+    if self.train_dataset is None:
+      raise ValueError("Trainer: training requires a train_dataset.")
+
+    num_replicas = xr.process_count()
+    logger.info(f"Num replicas: {num_replicas}")
+    sampler = torch.utils.data.DistributedSampler(
+        self.train_dataset,
+        num_replicas=num_replicas,
+        rank=xr.process_index(),
+    )
+    assert self.global_batch_size is not None
+    dataloader = DataLoader(
+        self.train_dataset,
+        # Data collator will default to DataCollatorWithPadding, so we change it.
+        collate_fn=default_data_collator,
+        # This is the host batch size.
+        batch_size=self.global_batch_size // num_replicas,
+        sampler=sampler,
+        drop_last=True,
+    )
+    loader = pl.MpDeviceLoader(
+        dataloader, self.device, input_sharding=self.input_sharding_spec)
+    return loader
+
+  def _shard_model(self, model):
+    default_transformer_cls_names_to_wrap = []
+    fsdp_transformer_layer_cls_to_wrap = self.args.fsdp_config.get(
+        "transformer_layer_cls_to_wrap",
+        default_transformer_cls_names_to_wrap,
+    )
+
+    transformer_cls_to_wrap = set()
+    for layer_class in fsdp_transformer_layer_cls_to_wrap:
+      transformer_cls = get_module_class_from_name(model, layer_class)
+      if transformer_cls is None:
+        raise Exception(
+            "Could not find the transformer layer class to wrap in the model.")
+      else:
+        transformer_cls_to_wrap.add(transformer_cls)
+    logger.info(f"Llama classes to wrap: {transformer_cls_to_wrap}")
+    auto_wrap_policy = functools.partial(
+        transformer_auto_wrap_policy,
+        # Transformer layer class to wrap
+        transformer_layer_cls=transformer_cls_to_wrap,
+    )
+
+    if self.args.fsdp_config["xla_fsdp_grad_ckpt"]:
+      # Apply gradient checkpointing to auto-wrapped sub-modules if specified
+      logger.info("Enabling gradient checkpointing")
+
+      def auto_wrapper_callable(m, *args, **kwargs):
+        target_cls = FSDPv2
+        return target_cls(checkpoint_module(m), *args, **kwargs)
+
+    def shard_output(output, mesh):
+      real_output = None
+      if isinstance(output, torch.Tensor):
+        real_output = output
+      elif isinstance(output, tuple):
+        real_output = output[0]
+      elif isinstance(output, CausalLMOutputWithPast):
+        real_output = output.logits
+      if real_output is None:
+        raise ValueError(
+            "Something went wrong, the output of the model shouldn't be `None`")
+      xs.mark_sharding(real_output, mesh, ("fsdp", None, None))
+
+    model = FSDPv2(
+        model,
+        shard_output=shard_output,
+        auto_wrap_policy=auto_wrap_policy,
+        auto_wrapper_callable=auto_wrapper_callable,
+    )
+
+    return model
+
+  def train_loop(self):
+    self.model.train()
+    self.model.zero_grad()
+
+    # For now we assume that we wil never train for mor than one epoch
+    max_step = self.args.max_steps
+    train_loader = self._get_train_dataloader()
+    train_iterator = iter(train_loader)
+
+    logger.info("Starting training")
+    logger.info(f"    Max step: {max_step}")
+    logger.info(f"    Global batch size: {self.global_batch_size}")
+
+    for step in range(max_step):
+      try:
+        batch = next(train_iterator)
+      except StopIteration:
+        break
+
+      # For logging step, we explicitly isolate this step from tracing and execution overlapping.
+      if step % self.args.logging_steps == 0:
+        xm.wait_device_ops()
+      trace_start_time = timer()
+
+      loss = self.train_step(batch)
+      xm.mark_step()
+
+      trace_end_time = timer()
+      if step % self.args.logging_steps == 0:
+        xm.wait_device_ops()
+        execute_end_time = timer()
+        logger.info(
+            f"Step: {step}, loss: {loss:0.4f}, trace time: {(trace_end_time - trace_start_time) * 1000:0.2f} ms, step time: {(execute_end_time - trace_end_time) * 1000:0.2f} ms"
         )
-        loader = pl.MpDeviceLoader(dataloader,
-                                   self.device,
-                                   input_sharding=self.input_sharding_spec)
-        return loader
 
-    def _shard_model(self, model):
-        default_transformer_cls_names_to_wrap = []
-        fsdp_transformer_layer_cls_to_wrap = self.args.fsdp_config.get(
-            "transformer_layer_cls_to_wrap",
-            default_transformer_cls_names_to_wrap)
-
-        transformer_cls_to_wrap = set()
-        for layer_class in fsdp_transformer_layer_cls_to_wrap:
-            transformer_cls = get_module_class_from_name(model, layer_class)
-            if transformer_cls is None:
-                raise Exception(
-                    "Could not find the transformer layer class to wrap in the model."
-                )
-            else:
-                transformer_cls_to_wrap.add(transformer_cls)
-        logger.info(f"Llama classes to wrap: {transformer_cls_to_wrap}")
-        auto_wrap_policy = functools.partial(
-            transformer_auto_wrap_policy,
-            # Transformer layer class to wrap
-            transformer_layer_cls=transformer_cls_to_wrap,
+      # Capture profile at the prefer step
+      if step == self.args.profile_step:
+        # Wait until device execution catches up to tracing before triggering the profile. This will
+        # interrupt training slightly on the hosts which are capturing, but by waiting after tracing
+        # for the step, the interruption will be minimal.
+        xm.wait_device_ops()
+        xp.trace_detached(
+            "127.0.0.1:9012",
+            self.args.profile_dir,
+            self.args.profile_duration,
         )
 
-        if self.args.fsdp_config["xla_fsdp_grad_ckpt"]:
-            # Apply gradient checkpointing to auto-wrapped sub-modules if specified
-            logger.info("Enabling gradient checkpointing")
+    logger.info("Finished training run")
 
-            def auto_wrapper_callable(m, *args, **kwargs):
-                target_cls = FSDPv2
-                return target_cls(checkpoint_module(m), *args, **kwargs)
-
-        def shard_output(output, mesh):
-            real_output = None
-            if isinstance(output, torch.Tensor):
-                real_output = output
-            elif isinstance(output, tuple):
-                real_output = output[0]
-            elif isinstance(output, CausalLMOutputWithPast):
-                real_output = output.logits
-            if real_output is None:
-                raise ValueError(
-                    "Something went wrong, the output of the model shouldn't be `None`"
-                )
-            xs.mark_sharding(real_output, mesh, ("fsdp", None, None))
-
-        model = FSDPv2(
-            model,
-            shard_output=shard_output,
-            auto_wrap_policy=auto_wrap_policy,
-            auto_wrapper_callable=auto_wrapper_callable,
-        )
-
-        return model
-
-    def train_loop(self):
-        self.model.train()
-        self.model.zero_grad()
-
-        # For now we assume that we wil never train for mor than one epoch
-        max_step = self.args.max_steps
-        train_loader = self._get_train_dataloader()
-        train_iterator = iter(train_loader)
-
-        logger.info("Starting training")
-        logger.info(f"    Max step: {max_step}")
-        logger.info(f"    Global batch size: {self.global_batch_size}")
-
-        for step in range(max_step):
-            try:
-                batch = next(train_iterator)
-            except StopIteration:
-                break
-
-            # For logging step, we explicitly isolate this step from tracing and execution overlapping.
-            if step % self.args.logging_steps == 0:
-                xm.wait_device_ops()
-            trace_start_time = timer()
-
-            loss = self.train_step(batch)
-            xm.mark_step()
-
-            trace_end_time = timer()
-            if step % self.args.logging_steps == 0:
-                xm.wait_device_ops()
-                execute_end_time = timer()
-                logger.info(
-                    f"Step: {step}, loss: {loss:0.4f}, trace time: {(trace_end_time - trace_start_time) * 1000:0.2f} ms, step time: {(execute_end_time - trace_end_time) * 1000:0.2f} ms"
-                )
-
-            # Capture profile at the prefer step
-            if step == self.args.profile_step:
-                # Wait until device execution catches up to tracing before triggering the profile. This will
-                # interrupt training slightly on the hosts which are capturing, but by waiting after tracing
-                # for the step, the interruption will be minimal.
-                xm.wait_device_ops()
-                xp.trace_detached('127.0.0.1:9012', self.args.profile_dir,
-                                  self.args.profile_duration)
-
-        logger.info("Finished training run")
-
-    def train_step(self, batch):
-        outputs = self.model(**batch)
-        loss = outputs.loss
-        loss.backward()
-        self.optimizer.step()
-        self.lr_scheduler.step()
-        self.model.zero_grad()
-        return loss
+  def train_step(self, batch):
+    outputs = self.model(**batch)
+    loss = outputs.loss
+    loss.backward()
+    self.optimizer.step()
+    self.lr_scheduler.step()
+    self.model.zero_grad()
+    return loss
 
 
 def main():
-    # Parse CLI arguments
-    parser = HfArgumentParser(
-        (ModelArguments, DataTrainingArguments, MoreTrainingArguments))
+  # Parse CLI arguments
+  parser = HfArgumentParser(
+      (ModelArguments, DataTrainingArguments, MoreTrainingArguments))
 
-    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
-        # If we pass only one argument to the script and it's the path to a json file,
-        # let's parse it to get our arguments.
-        model_args, data_args, training_args = parser.parse_json_file(
-            json_file=os.path.abspath(sys.argv[1]))
-    else:
-        model_args, data_args, training_args = parser.parse_args_into_dataclasses(
-        )
+  if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+    # If we pass only one argument to the script and it's the path to a json file,
+    # let's parse it to get our arguments.
+    model_args, data_args, training_args = parser.parse_json_file(
+        json_file=os.path.abspath(sys.argv[1]))
+  else:
+    model_args, data_args, training_args = (
+        parser.parse_args_into_dataclasses())
 
-    # Configure logging
-    if training_args.should_log:
-        # The default of training_args.log_level is passive, so we set log level at info here to have that default.
-        transformers.utils.logging.set_verbosity_info()
+  # Configure logging
+  if training_args.should_log:
+    # The default of training_args.log_level is passive, so we set log level at info here to have that default.
+    transformers.utils.logging.set_verbosity_info()
 
-    log_level = training_args.get_process_log_level()
-    logger.setLevel(log_level)
-    datasets.utils.logging.set_verbosity(log_level)
-    transformers.utils.logging.set_verbosity(log_level)
-    transformers.utils.logging.enable_default_handler()
-    transformers.utils.logging.enable_explicit_format()
+  log_level = training_args.get_process_log_level()
+  logger.setLevel(log_level)
+  datasets.utils.logging.set_verbosity(log_level)
+  transformers.utils.logging.set_verbosity(log_level)
+  transformers.utils.logging.enable_default_handler()
+  transformers.utils.logging.enable_explicit_format()
 
-    set_seed(training_args.seed)
-    server = xp.start_server(9012)
-    logger.info(f'Profiling server started: {str(server)}')
+  set_seed(training_args.seed)
+  server = xp.start_server(9012)
+  logger.info(f"Profiling server started: {str(server)}")
 
-    tokenizer_name = model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_id
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
-    config = AutoConfig.from_pretrained(model_args.model_id)
-    config.flash_attention = True
-    model = LlamaForCausalLM(config)
-    n_params = sum([p.numel() for p in model.parameters()])
-    logger.info(
-        f"Training new model from scratch - Total size={n_params} params")
+  tokenizer_name = (
+      model_args.tokenizer_name
+      if model_args.tokenizer_name else model_args.model_id)
+  tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+  config = AutoConfig.from_pretrained(model_args.model_id)
+  config.flash_attention = True
+  model = LlamaForCausalLM(config)
+  n_params = sum([p.numel() for p in model.parameters()])
+  logger.info(f"Training new model from scratch - Total size={n_params} params")
 
-    # Set the model dtype to bfloat16
-    model = model.to(torch.bfloat16)
+  # Set the model dtype to bfloat16
+  model = model.to(torch.bfloat16)
 
-    # Downloading and loading a dataset from the hub.
-    data = load_dataset(
-        data_args.dataset_name,
-        data_args.dataset_config_name,
-        cache_dir=model_args.cache_dir,
-    )["train"]
-    column_names = list(data.features)
-    data = data.map(lambda samples: tokenizer(samples["text"]),
-                    batched=True,
-                    remove_columns=column_names)
+  # Downloading and loading a dataset from the hub.
+  data = load_dataset(
+      data_args.dataset_name,
+      data_args.dataset_config_name,
+      cache_dir=model_args.cache_dir,
+  )["train"]
+  column_names = list(data.features)
+  data = data.map(
+      lambda samples: tokenizer(samples["text"]),
+      batched=True,
+      remove_columns=column_names,
+  )
 
-    # Taken from run_clm.py. It's important to group texts evenly to avoid recompilations in TPU.
-    block_size = data_args.block_size
+  # Taken from run_clm.py. It's important to group texts evenly to avoid recompilations in TPU.
+  block_size = data_args.block_size
 
-    def group_texts(examples):
-        from itertools import chain
-        # Concatenate all texts.
-        concatenated_examples = {
-            k: list(chain(*examples[k]))
-            for k in examples.keys()
-        }
-        total_length = len(concatenated_examples[list(examples.keys())[0]])
-        # We drop the small remainder, and if the total_length < block_size  we exclude this batch and return an empty dict.
-        # We could add padding if the model supported it instead of this drop, you can customize this part to your needs.
-        total_length = (total_length // block_size) * block_size
-        # Split by chunks of max_len.
-        result = {
-            k:
-            [t[i:i + block_size] for i in range(0, total_length, block_size)]
-            for k, t in concatenated_examples.items()
-        }
-        result["labels"] = result["input_ids"].copy()
-        return result
+  def group_texts(examples):
+    from itertools import chain
 
-    data = data.map(group_texts, batched=True)
+    # Concatenate all texts.
+    concatenated_examples = {k: list(chain(*examples[k])) for k in examples}
+    total_length = len(concatenated_examples[list(examples.keys())[0]])
+    # We drop the small remainder, and if the total_length < block_size  we exclude this batch and return an empty dict.
+    # We could add padding if the model supported it instead of this drop, you can customize this part to your needs.
+    total_length = (total_length // block_size) * block_size
+    # Split by chunks of max_len.
+    result = {
+        k: [t[i:i + block_size] for i in range(0, total_length, block_size)]
+        for k, t in concatenated_examples.items()
+    }
+    result["labels"] = result["input_ids"].copy()
+    return result
 
-    trainer = Trainer(
-        model=model,
-        args=training_args,
-        train_dataset=data,
-    )
+  data = data.map(group_texts, batched=True)
 
-    trainer.train_loop()
+  trainer = Trainer(
+      model=model,
+      args=training_args,
+      train_dataset=data,
+  )
+
+  trainer.train_loop()
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        datefmt="%m/%d/%Y %H:%M:%S",
-        handlers=[logging.StreamHandler(sys.stdout)],
-    )
-    main()
+  logging.basicConfig(
+      format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+      datefmt="%m/%d/%Y %H:%M:%S",
+      handlers=[logging.StreamHandler(sys.stdout)],
+  )
+  main()


### PR DESCRIPTION
This (should be) no-op change formats and fixes lint errors for all files.

Before we got more code this change standardizes the style.

I copied `torch_xla`'s yapf config for uniformity.

I added a guide to run `pytest` to unit test the code.

`torch_xla` doesn't have a linter; I picked `ruff` which is a fast linter.

Fixe #7 