### PR TITLE
Add a .dockerignore file linked to .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
`.dockerignore` can avoid adding unnecessary files (like venv or pycache) to the docker image. As a start, we can reuse `.gitignore`

This speeds up the docker context copy time.