### PR TITLE
Linter and formatter CI and GHA check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,51 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+  - cron: "0 10 * * *"
+
+jobs:
+  lint:
+    name: Check format and lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[dev]'
+    - name: Lint the code with ruff
+      run: |
+        ruff check
+    - name: Check formatting with yapf
+      shell: bash
+      run: |
+        git_status=$(git status --porcelain)
+        if [[ $git_status ]]; then
+          echo "Checkout code is not clean"
+          echo "${git_status}"
+          exit 1
+        fi
+
+        yapf --recursive -i '*.py' torchprime launcher
+        git_status=$(git status --porcelain)
+        if [[ $git_status ]]; then
+          git diff
+          echo "yapf recommends the changes above, please manually apply them OR automatically apply the changes "
+          echo "by running `yapf -i /PATH/TO/foo.py` to the following files"
+          echo "${git_status}"
+          exit 1
+        else
+          echo "PASSED Python format"
+        fi


### PR DESCRIPTION
This change adds a CI as well as GitHub Action based check for pushes and PRs that checks the code formatting and lints.

I copied the formatter check from `torch_xla`

Addresses part of #8 

Test: this PR will have checks