### PR TITLE
Install torch_xla2 in GitHub action checks

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -18,6 +18,9 @@ jobs:
       image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_${{ matrix.python-version }}_tpuvm
     steps:
     - uses: actions/checkout@v4
+    - name: Install torchax
+      run: |
+        pip install 'torch_xla2 @ git+https://git@github.com/pytorch/xla.git#subdirectory=experimental/torch_xla2'
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 dev = [
     "ruff~=0.8.6",
     "pytest~=8.3.4",
+    "pytest-forked~=1.6.0",
     "yapf~=0.43.0"
 ]
 
@@ -38,6 +39,10 @@ exclude = ["torchprime.*.tests.*"]
 
 [tool.setuptools.package-data]
 "torchprime" = ["py.typed"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--forked"  # ensure torchax and torch_xla tests don't conflict
 
 [tool.ruff]
 indent-width = 4
@@ -61,4 +66,3 @@ select = [
 ignore = [
     "E501",  # Line too long. Some copied GPU code has lengthy comments.
 ]
-

--- a/torchprime/experimental/torchax_models/tests/test_import_torchax.py
+++ b/torchprime/experimental/torchax_models/tests/test_import_torchax.py
@@ -1,0 +1,10 @@
+import unittest
+
+
+class TestImportTorchax(unittest.TestCase):
+
+  def test_import_torchax(self):
+    """
+    This test checks that `torchax` is installed.
+    """
+    import torch_xla2  # noqa: F401


### PR DESCRIPTION
By default, torch_xla2 is not installed in our testing containers, which use the torch_xla docker. This fixes that.

Test: added a test to just import torch_xla2. Run `pytest`.