### PR TITLE
Add llama test

### DIFF
--- a/torchprime/torch_xla_models/tests/test_llama.py
+++ b/torchprime/torch_xla_models/tests/test_llama.py
@@ -73,12 +73,12 @@ class TestYourModule(unittest.TestCase):
             llama_output_native.logits,
             llama_output.logits.to('cpu'),
             atol=1e-2),
-        "CPU run and TPU run logits are not equal",
+        "CPU run and XLA run logits are not equal",
     )
     self.assertTrue(
         torch.allclose(
             llama_output_native.loss, llama_output.loss.to('cpu'), atol=1e-2),
-        "CPU run and TPU run loss is not equal",
+        "CPU run and XLA run loss is not equal",
     )
 
 

--- a/torchprime/torch_xla_models/train.py
+++ b/torchprime/torch_xla_models/train.py
@@ -387,8 +387,8 @@ def main():
     total_length = (total_length // block_size) * block_size
     # Split by chunks of max_len.
     result = {
-        k: [t[i:i + block_size] for i in range(0, total_length, block_size)
-           ] for k, t in concatenated_examples.items()
+        k: [t[i:i + block_size] for i in range(0, total_length, block_size)]
+        for k, t in concatenated_examples.items()
     }
     result["labels"] = result["input_ids"].copy()
     return result


### PR DESCRIPTION
Resolve https://github.com/AI-Hypercomputer/torchprime/issues/6.

Note, there are two issues in torch_xla run, as in `torchprime/experimental/torchax_models/test/test_llama.py`

1) Error between torch_xla and native pytorch CPU run is qute obvious, at level of ~ 0.1.
2) scaled_dot_product is not been replaced with flash_attention kernel for torch_xla. This requires the code change to the model.


I kind of messed up PR https://github.com/AI-Hypercomputer/torchprime/pull/26 with rebased to a commit. Opened this new one instead...