### PR TITLE
[torchax] Fix Llama 3.1 405B host memory space OOM

### DIFF
--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -28,9 +28,7 @@ WORKDIR /workspaces/xla/experimental/torch_xla2
 RUN pip install torch_xla[pallas] \
     -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
     -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-RUN pip install -e .[tpu] \
-    -f https://storage.googleapis.com/libtpu-releases/index.html \
-    -f https://storage.googleapis.com/libtpu-wheels/index.html 
+RUN pip install -e .
 
 # Install torchprime
 WORKDIR /workspaces/torchprime

--- a/launcher/run_xpk.py
+++ b/launcher/run_xpk.py
@@ -19,7 +19,8 @@ jobset_name = os.getenv("JOBSET_NAME", date_string)
 xla_dump_path = (
     f"{gcs_mount}/llama3-{slice_id}-{worker_id}/xla_dumps/{jobset_name}/")
 os.environ["XLA_FLAGS"] = (
-    os.getenv("XLA_FLAGS", "") + f" --xla_dump_to={xla_dump_path}")
+    os.getenv("XLA_FLAGS", "") +
+    f" --xla_dump_to={xla_dump_path} --xla_dump_hlo_as_proto")
 print(f"Dumping XLA compiler outputs to {xla_dump_path}")
 
 # Determine the profile dir

--- a/torchprime/experimental/torchax_models/README.md
+++ b/torchprime/experimental/torchax_models/README.md
@@ -55,7 +55,7 @@ Replace `CLUSTER_NAME`, `PROJECT_ID`, and `ZONE` with appropiate values.
 |device| Model size | Batch size | seq length | step time | MFU | NOTEs|
 |-------| ----- | ----- | ----- | ----- | ----- | ---|
 |TPU v6e-8| 8B |        8 |      8192 | 1.7s | 30% | Scan, fsdp, host-offload|
-|TPU v6e-256 x 2| 405B | 256 | 8192 | 46.12s | 25.8% | Scan, fsdp + tp, host-offload|
+|TPU v6e-256 x 2| 405B | 256 | 8192 | 46.12s | 28.7% | Scan, fsdp + tp, host-offload|
 
 <!-- TODO: support specifying different XLA flags -->
 

--- a/torchprime/experimental/torchax_models/llama/model_with_scan.py
+++ b/torchprime/experimental/torchax_models/llama/model_with_scan.py
@@ -335,6 +335,7 @@ class TransformerBlock(nn.Module):
       freqs_cis: torch.Tensor,
       mask: torch.Tensor | None,
   ):
+    x = with_sharding_constraint(x, P("fsdp", None, "tp"))
     x = interop.call_jax(checkpoint_name, x, "decoder_layer_input")
     h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
     out = h + self.feed_forward(self.ffn_norm(h))


### PR DESCRIPTION
This fixes #28. Currently each graph uses >128GiB of host RAM per TPU chip, which is not supported. The OOMing host array is `bf16[126, 2, 8192, 16384]`.

Based on the shape and https://pytorch.org/blog/high-performance-llama-2 I made an informed guess to annotate the decoder input with sharding constraints. That got rid of the OOM and we calculate an MFU of 28.65%.

Training output snippet:

```
program size: 0.316734 m chars
End compiling 41.968193726148456
Compile time: 41.968193726148456
Flops 447646288314368.0
GB accessed 433.546264576
0 loss 6272 bfloat16 step latency: 132.53140141186304
======
INPUT shape torch.Size([256, 8192])
1 loss 6272 bfloat16 step latency: 41.24516941001639
======
INPUT shape torch.Size([256, 8192])
2 loss 6272 bfloat16 step latency: 40.27528425701894
======
INPUT shape torch.Size([256, 8192])
3 loss 6272 bfloat16 step latency: 40.21413461607881
======
INPUT shape torch.Size([256, 8192])
4 loss 6272 bfloat16 step latency: 40.22760192491114
======
INPUT shape torch.Size([256, 8192])
5 loss 6272 bfloat16 step latency: 41.25447623594664
======
INPUT shape torch.Size([256, 8192])
6 loss 6272 bfloat16 step latency: 42.87271257000975
======
```