### PR TITLE
Add a `tp -i` for interactive workflows

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -30,4 +30,6 @@ jobs:
         # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/14): Remove and burn the token.
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        pytest
+        export PJRT_DEVICE=CPU
+        export JAX_PLATFORMS=cpu
+        pytest -v

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ How to run tests:
 pytest
 ```
 
+How to run some of the tests, and re-run them whenever you change a file:
+
+```sh
+tp -i test ... # replace with path to tests/directories
+```
+
 How to format:
 
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dev = [
     "click~=8.1.8",
     "toml~=0.10.2",
     "dataclasses-json~=0.6.7",
+    "watchdog~=6.0.0",
+    "pathspec~=0.12.1",
     "xpk@git+https://github.com/AI-Hypercomputer/xpk"
 ]
 


### PR DESCRIPTION
With this change, we can run:

- `tp -i test ...` to run some unit tests
- `tp -i run ...` to run a distributed SPMD command

And the script will monitor the filesystem for changes. It will re-trigger the command again whenever one changes a file, leading to an ergonomic dev/test cycle.

I also found some flags to make the CPU checks faster.

Tested: `tp -i test torchprime/torch_xla_models` to repeatedly run the torch_xla model tests upon edit.
