### PR TITLE
Fix profiling of torchax models

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ XLA_IR_DEBUG=1 XLA_HLO_DEBUG=1 python3 torchprime/torch_xla_models/train.py
 Train Llama 3 8B using torchax:
 
 ```sh
-python3 torchprime/experimental/torchax_models/run.py --batch_size=16
+python3 torchprime/experimental/torchax_models/run.py global_batch_size=16
 ```
 
 Refer to `README.md` in `torchprime/torch_xla_models` and
@@ -62,7 +62,7 @@ Then prepend `tp run` to a particular Python file you would like to
 run remotely, including arguments, e.g.
 
 ```sh
-tp run torchprime/experimental/torchax_models/run.py --batch_size=256
+tp run torchprime/experimental/torchax_models/run.py global_batch_size=256
 ```
 
 `tp run` will broadcast this command to all VMs in the XPK cluster,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "datasets==3.0.0",
     "hydra-core==1.3.0",
     "optax==0.2.4",
-    "fire==0.7.0",
     "tensorflow-cpu==2.18.0",
     "tensorboard==2.18.0",
     "tensorboard-plugin-profile==2.18.0",

--- a/torchprime/experimental/torchax_models/README.md
+++ b/torchprime/experimental/torchax_models/README.md
@@ -36,7 +36,7 @@ pip install torch --index-url https://download.pytorch.org/whl/cpu
 git clone https://github.com/pytorch/xla.git
 cd xla/torchax
 pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-pip install optax fire tensorflow tensorboard-plugin-profile
+pip install optax tensorflow tensorboard-plugin-profile
 pip install -e .[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
 ```
 
@@ -65,12 +65,12 @@ Llama 3.1 405B on v6e-256 x 2 command:
 
 ```sh
 tp run torchprime/experimental/torchax_models/run.py \
-    --batch_size=256 \
-    --model_type=405B \
-    --seqlen=8192 \
-    --use_custom_offload=True \
-    --use_custom_mesh=True \
-    --model_impl=scan \
-    --tp=4 \
-    --unroll_layers=1
+    global_batch_size=256 \
+    model_type=405B \
+    seqlen=8192 \
+    use_custom_offload=True \
+    use_custom_mesh=True \
+    model_impl=scan \
+    tp=4 \
+    unroll_layers=1
 ```

--- a/torchprime/experimental/torchax_models/configs/default.yaml
+++ b/torchprime/experimental/torchax_models/configs/default.yaml
@@ -1,0 +1,16 @@
+# The default config file. You may override configs with `key=value` arguments on the CLI
+# according to https://hydra.cc/docs/advanced/override_grammar/basic/.
+
+global_batch_size: 64
+model_type: 8B
+lr: 5.e-5
+tp: 4
+seqlen: 2048
+model_impl: scan
+use_custom_mesh: False
+use_custom_offload: True
+internal_override_layers: -1
+
+# This might be overwritten when using tp run to launch the run using XPK
+profile_dir: profile
+unroll_layers: 1

--- a/torchprime/experimental/torchax_models/llama/model_with_scan.py
+++ b/torchprime/experimental/torchax_models/llama/model_with_scan.py
@@ -11,7 +11,6 @@
 # https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/model.py
 
 import math
-from dataclasses import dataclass
 
 import jax
 import torch
@@ -21,40 +20,9 @@ from jax.sharding import PartitionSpec as P
 from torch import nn
 from torchax import interop
 
+from .model import ModelArgs
+
 with_sharding_constraint = interop.torch_view(jax.lax.with_sharding_constraint)
-
-
-@dataclass
-class ModelArgs:
-  dim: int = 4096
-  n_layers: int = 32
-  n_heads: int = 32
-  n_kv_heads: int | None = None
-  vocab_size: int = -1
-  multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
-  ffn_dim_multiplier: float | None = None
-  norm_eps: float = 1e-5
-  rope_theta: float = 500000
-  use_scaled_rope: bool = False
-
-  max_batch_size: int = 32
-  max_seq_len: int = 8192
-
-  # vision model params
-  vision_chunk_size: int = -1  # image resolution for image models
-  vision_max_num_chunks: int = 4
-  vision_num_cross_attention_layers: int = -1
-
-  def __init__(self, **kwargs):
-    for k, v in kwargs.items():
-      if hasattr(self, k):
-        setattr(self, k, v)
-
-    if self.n_kv_heads is None:
-      self.n_kv_heads = self.n_heads
-    assert self.n_kv_heads <= self.n_heads
-    assert self.n_heads % self.n_kv_heads == 0
-    assert self.dim % self.n_heads == 0
 
 
 # **NOTE**: This code is not runnable without installing `torch` and `fairscale`

--- a/torchprime/torch_xla_models/configs/default.yaml
+++ b/torchprime/torch_xla_models/configs/default.yaml
@@ -1,3 +1,6 @@
+# The default config file. You may override configs with `key=value` arguments on the CLI
+# according to https://hydra.cc/docs/advanced/override_grammar/basic/.
+
 # This defines the order in which configs are loaded. The latter configs
 # override the earlier ones.
 defaults:
@@ -13,8 +16,9 @@ block_size: 8192
 cache_dir: /tmp/
 seed: 42
 profile_step: -1
+
 # This might be overwritten when using tp run to launch the run using XPK
-profile_dir: /tmp/profile 
+profile_dir: profile
 profile_duration: 100000
 optimizer:
   learning_rate: 5.e-5

--- a/torchprime/torch_xla_models/train.py
+++ b/torchprime/torch_xla_models/train.py
@@ -277,7 +277,7 @@ def initialize_model_class(model_config):
   return model
 
 
-@hydra.main(version_base=None, config_path="configs", config_name="base")
+@hydra.main(version_base=None, config_path="configs", config_name="default")
 def main(config: DictConfig):
   # Configure logging
   print(OmegaConf.to_yaml(config))  # Print the config for debugging


### PR DESCRIPTION
Since torch_xla uses hydra, the CLI for setting profile dir changed slightly. In order to profile torchax training, we refactor both to use hydra and the same config name for setting profile dir.

I didn't do that in this PR, but it will be simpler to extend the torchax trainer to train both llama and mixtral via configs later.

Tested:

```
  python3 torchprime/experimental/torchax_models/run.py global_batch_size=16

  tp run torchprime/experimental/torchax_models/run.py \
    global_batch_size=256 \
    model_type=405B \
    seqlen=8192 \
    use_custom_offload=True \
    use_custom_mesh=True \
    model_impl=scan \
    tp=4 \
    unroll_layers=1
```