### PR TITLE
Improve `tp doctor` checking for cluster existance

### DIFF
--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -125,7 +125,7 @@ def use(
 
   path = write_config(config)
   click.echo(f"Written config {path.relative_to(os.getcwd())}")
-  torchprime.launcher.doctor.check_all()
+  torchprime.launcher.doctor.check_all(config)
 
 
 def create_and_activate_gcloud(gcloud_config_name, config: Config):

--- a/torchprime/launcher/doctor.py
+++ b/torchprime/launcher/doctor.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import click
 
+from torchprime.launcher.cli import Config
+
 
 class CheckFailedError(Exception):
   pass
@@ -114,20 +116,64 @@ def check_gke_gcloud_auth_plugin():
   )
 
 
-def check_all():
+def check_gke_cluster_exist(config: Config):
+  """Check that the GKE cluster exists."""
+  try:
+    # Run `gcloud components list` to get installed components
+    result = subprocess.run(
+      [
+        "gcloud",
+        "container",
+        "clusters",
+        "describe",
+        f"{config.cluster}",
+        f"--project={config.project}",
+        f"--zone={config.zone}",
+      ],
+      check=True,
+      capture_output=True,
+      text=True,
+    )
+  except subprocess.CalledProcessError as e:
+    print(
+      f"Error running gcloud command: {e.stderr} Please check the cluster name and project"
+    )
+    # get existing clusters in the project
+    try:
+      result = subprocess.run(
+        ["gcloud", "container", "clusters", "list", f"--project={config.project}"],
+        check=True,
+        capture_output=True,
+        text=True,
+      )
+      print(f"Available clusters in the project: \n{result.stdout}")
+    except subprocess.CalledProcessError as e:
+      print(f"Error running gcloud command: {e.stderr} Unable to get existing clusters")
+    raise CheckFailedError(
+      f"""The GKE cluster `{config.cluster}` does not exist in project `{config.project}` in zone `{config.zone}`"""
+    ) from e
+
+
+def check_all(config: Config | None = None):
   click.echo("Checking environment...")
-  for check in [
+  check_list = [
     check_docker,
     check_gcloud_auth_login,
     check_gcr_io,
     check_docker_access,
     check_kubectl,
     check_gke_gcloud_auth_plugin,
-  ]:
+  ]
+  if config:
+    check_list.append(check_gke_cluster_exist)
+  for check in check_list:
     assert check.__doc__ is not None
     click.echo(check.__doc__ + "..", nl=False)
     try:
-      check()
+      try:
+        check(config)
+      except TypeError:
+        check()
     except CheckFailedError as e:
       click.echo()
       click.echo()

--- a/torchprime/launcher/doctor.py
+++ b/torchprime/launcher/doctor.py
@@ -9,10 +9,11 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TypeVar
 
 import click
 
-from torchprime.launcher.cli import Config
+ConfigT = TypeVar("ConfigT", bound="Config")  # noqa: F821
 
 
 class CheckFailedError(Exception):
@@ -116,10 +117,9 @@ def check_gke_gcloud_auth_plugin():
   )
 
 
-def check_gke_cluster_exist(config: Config):
+def check_gke_cluster_exist(config: ConfigT | None = None):
   """Check that the GKE cluster exists."""
   try:
-    # Run `gcloud components list` to get installed components
     result = subprocess.run(
       [
         "gcloud",
@@ -154,7 +154,7 @@ def check_gke_cluster_exist(config: Config):
     ) from e
 
 
-def check_all(config: Config | None = None):
+def check_all(config: ConfigT | None = None):
   click.echo("Checking environment...")
   check_list = [
     check_docker,


### PR DESCRIPTION
Add the checking for the specified XPK clusters. Previously if users made a mistake in specify cluster name/zone/project, it will only error out after finish building the XPK docker image.

Improved terminal output:
```
$ tp use     --cluster $XPK_CLUSTER_NAME     --project tpu-pytorch     --zone us-east1-b     --num-slices 1     --tpu-type v6e-256     --artifact-dir gs://piz/torc
hprime/llama3/performance/
Activating gcloud config...
Written config .config/default.toml
Checking environment...
Check that docker is installed... ✅
Check that gcloud is logged in... ✅
Check that docker config contains gcr.io credential helper... ✅
Check that the gcloud account can access the gcr.io artifact registry... ✅
Check that kubectl is installed... ✅
Check that gke-gcloud-auth-plugin is installed... ✅
Check that the GKE cluster exists...Error running gcloud command: ERROR: (gcloud.container.clusters.describe) ResponseError: code=404, message=Not found: projects/tpu-pytorch/zones/us-east1-b/clusters/pytorch-v6e-256-donotdelete-uj. This command is authenticated as 164006649440-compute@developer.gserviceaccount.com which is the active account specified by the [core/account] property.
Could not find [pytorch-v6e-256-donotdelete-uj] in [us-east1-b].
Did you mean [pytorch-v6e-256-donotdelete-uj] in [us-east1]?
 Please check the cluster name and project
Available clusters in the project: 
NAME                                     LOCATION        MASTER_VERSION      MASTER_IP        MACHINE_TYPE     NODE_VERSION          NUM_NODES  STATUS
gke256                                   europe-west4-a  1.31.4-gke.1256000  34.34.73.37      n1-standard-8    1.31.4-gke.1256000    4          RUNNING
gke256test                               europe-west4-a  1.31.4-gke.1256000  10.164.0.7       n1-standard-8    1.31.4-gke.1256000    4          RUNNING
tpu-cluster                              europe-west4-a  1.30.8-gke.1051000  34.90.106.164    e2-medium        1.22.16-gke.2000 ***  5          RUNNING
autopilot-cluster-1                      us-central1     1.30.8-gke.1162000  34.68.210.9                                                        RUNNING
ptxla-cluster-gpu-benchmark              us-central1-a   1.30.8-gke.1162000  34.172.214.147   e2-medium        1.30.8-gke.1162000    3          RUNNING
pytorch-v6e-testing                      us-central2     1.31.4-gke.1372000  35.186.137.49    n1-standard-8    1.31.4-gke.1372000    1          RUNNING
tpu-ci                                   us-central2     1.31.4-gke.1372000  35.186.48.33     n1-standard-1    1.31.4-gke.1372000    5          RUNNING
tpu-ci-test                              us-central2     1.31.4-gke.1372000  107.167.160.244  ct4p-hightpu-4t  1.31.4-gke.1372000    3          RUNNING
pytorch-v6e-256-donotdelete-uj           us-east1        1.31.5-gke.1023000  34.148.152.179   n1-standard-8    1.31.5-gke.1023000    132        RUNNING
us-west1-cowanmeg-metrics2-7c7928df-gke  us-west1-b      1.30.8-gke.1051000  35.197.42.227    n1-standard-4    1.30.8-gke.1051000    3          RUNNING
```