### PR TITLE
Temporarily pin Docker base image to 2.6 stable

### DIFF
--- a/torchprime/launcher/Dockerfile
+++ b/torchprime/launcher/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:experimental
-# Use torch_xla Python 3.10 nightly as the base image
-FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_cxx11
+# Use torch_xla Python 3.10 as the base image
+# TODO(https://github.com/pytorch/xla/issues/8683): Go back to nightly once the linked segfault is fixed.
+FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.6.0_3.10_tpuvm_cxx11
 
 # Install system dependencies
 RUN apt-get update && apt-get upgrade -y


### PR DESCRIPTION
Without this, workload crashes on trillium pods

We should undo this when https://github.com/pytorch/xla/issues/8683 is fixed