### PR TITLE
torch_xla trainer uses sharding config

### DIFF
--- a/torchprime/sharding/shard_model.py
+++ b/torchprime/sharding/shard_model.py
@@ -1,4 +1,6 @@
+import re
 from collections.abc import Callable
+from copy import copy
 from typing import Optional
 
 import torch.nn
@@ -27,7 +29,7 @@ ShardActivationFn optionally transforms a module based on its name.
 Args:
 
   module (torch.nn.Module): The module to be transformed.
-  
+
   name (str): The name of the module as it appears in the state dict.
 
 Returns:
@@ -51,14 +53,23 @@ def shard_model(
   for name, param in model.state_dict().items():
     state_dict[name] = shard_weight(param, name)
   model.load_state_dict(state_dict, assign=True)
-  return _wrap_module(model, shard_activation, tuple())
+  return wrap_module(model, shard_activation)
 
 
-def _wrap_module(
-  mod: torch.nn.Module, shard_activation: ShardActivationFn, prefix: tuple[str, ...]
+ModuleTransform = Callable[[torch.nn.Module, str], torch.nn.Module]
+"""
+A transform takes a module and its fully qualified name (as a dot-joined string)
+and returns the (possibly) transformed module.
+"""
+
+
+def wrap_module(
+  mod: torch.nn.Module, transform: ModuleTransform, prefix: tuple[str, ...] = tuple()
 ) -> torch.nn.Module:
   """
-  Recursively transforms the modules to shard activations.
+  Recursively transforms the modules by calling `transform` on them.
+
+  You may use this to apply sharding, checkpointing, optimization barriers, etc.
 
   Start from the leaf modules and work our way up, to handle cases where one
   module is the child of another. The child modules will be transformed first,
@@ -67,13 +78,13 @@ def _wrap_module(
   """
   new_children = {}
   for name, child in mod.named_children():
-    new_children[name] = _wrap_module(child, shard_activation, prefix + (name,))
+    new_children[name] = wrap_module(child, transform, prefix + (name,))
   for name, new_child in new_children.items():
     mod.set_submodule(name, new_child)
-  return shard_activation(mod, ".".join(prefix))
+  return transform(mod, ".".join(prefix))
 
 
-# TODO(https://github.com/AI-Hypercomputer/torchprime/issues/86): Add framework specific wrappers.
+TAIL_INDEX_REGEX = re.compile(r"\[\d+\]$")
 
 
 def shard_model_from_config(
@@ -97,6 +108,11 @@ def shard_model_from_config(
       'model.layers.*': ['fsdp', None, None],
       # An empty string matches the output of the entire module.
       '': ['fsdp', None, None],
+
+      # Advanced usage: an index at the end means indexing into a particular
+      # output of a module, then sharding that. This is useful if your module
+      # output is a list or tensor and only one of the element should be sharded.
+      'model.layers.*[0]': ['fsdp', None, None],
     }
 
     model = shard_model_from_config(model, config, xs.mark_sharding)
@@ -112,6 +128,7 @@ def shard_model_from_config(
   if shard_param is None:
     shard_param = shard_output
 
+  config, shard_output_fns = _process_tail_index_syntax(config, shard_output)
   seen_params = set()
   seen_modules = set()
 
@@ -128,7 +145,7 @@ def shard_model_from_config(
     spec = config.get(name)
     if spec is not None:
       seen_modules.add(name)
-      return ShardedModule(mod, shard_output, tuple(spec))
+      return ShardedModule(mod, shard_output_fns.get(name, shard_output), tuple(spec))
     return mod
 
   model = shard_model(model, shard_weight, shard_activation)
@@ -140,7 +157,8 @@ def shard_model_from_config(
     seen_names == want_names
   ), f"""Requested to shard these names: {want_names}, but only sharded these: {seen_names}.
   
-These names were not found in the model: {diff}.
+These names were not found in the model:
+{diff}
 """
 
   return model
@@ -201,6 +219,47 @@ def shard_torch_xla_model_from_config(
     return xs.mark_sharding(tensor, the_mesh, spec).global_tensor
 
   return shard_model_from_config(model, config, shard_fn)
+
+
+def _process_tail_index_syntax(
+  config: dict,
+  shard_output: Callable[[torch.Tensor, tuple[str, ...]], torch.Tensor],
+):
+  """
+  Replace names like `model.layers.*[0]` with `model.layers.*` and add a
+  custom sharding function that just shards the requested element.
+  """
+
+  shard_output_fns = {}
+  config = copy(config)
+  for name in list(config.keys()):
+    matches = TAIL_INDEX_REGEX.search(name)
+    if matches is None:
+      continue
+    new_name = name[: matches.start()]
+    assert new_name not in config, f"{name} conflicts with {new_name}"
+    config[new_name] = config[name]
+    del config[name]
+    index = int(matches.group(0)[1:-1])
+
+    # This lambda indexes into the module output and shards the element we want.
+    def make_shard_output_fn(index):
+      def shard_output_fn(outputs, spec):
+        sharded = shard_output(outputs[index], spec)
+        out_list = list(outputs[:index]) + [sharded] + list(outputs[index + 1 :])
+        if isinstance(outputs, list):
+          return out_list
+        else:
+          assert isinstance(
+            outputs, tuple
+          ), f"outputs must be a list or tuple, got {type(outputs)}"
+          return tuple(out_list)
+
+      return shard_output_fn
+
+    shard_output_fns[new_name] = make_shard_output_fn(index)
+
+  return config, shard_output_fns
 
 
 def _process_sharding_name(name):

--- a/torchprime/torch_xla_models/configs/model/llama-3-8b.yaml
+++ b/torchprime/torch_xla_models/configs/model/llama-3-8b.yaml
@@ -1,4 +1,8 @@
-model_class: llama.LlamaForCausalLM # Used to import the model from this class
+defaults:
+  - _self_  # refers to this config file
+  - scaling: llama-fsdp  # refers to scaling/llama-fsdp.yaml
+
+model_class: llama.LlamaForCausalLM  # Used to import the model from this class
 vocab_size: 128256
 hidden_size: 4096
 intermediate_size: 14336
@@ -16,7 +20,3 @@ attention_dropout: false
 attention_bias: false
 flash_attention: true
 rope_theta: 500000.0
-fsdp:
-  transformer_layer_cls_to_wrap:
-    - LlamaDecoderLayer
-  xla_fsdp_grad_ckpt: true

--- a/torchprime/torch_xla_models/configs/model/mixtral-8x7b.yaml
+++ b/torchprime/torch_xla_models/configs/model/mixtral-8x7b.yaml
@@ -1,4 +1,8 @@
-model_class: mixtral.MixtralForCausalLM # Used to import the model from this class
+defaults:
+  - _self_  # refers to this config file
+  - scaling: mixtral-fsdp  # refers to scaling/mixtral-fsdp.yaml
+
+model_class: mixtral.MixtralForCausalLM  # Used to import the model from this class
 bos_token_id: 1
 eos_token_id: 2
 hidden_size: 4096
@@ -19,7 +23,3 @@ attention_dropout: 0.0
 flash_attention: true
 moe_implementation: gmm
 tokenizer_name: mistralai/Mixtral-8x7B-v0.1
-fsdp:
-  transformer_layer_cls_to_wrap:
-    - MixtralDecoderLayer
-  xla_fsdp_grad_ckpt: true

--- a/torchprime/torch_xla_models/configs/model/scaling/llama-fsdp.yaml
+++ b/torchprime/torch_xla_models/configs/model/scaling/llama-fsdp.yaml
@@ -1,0 +1,25 @@
+activation_checkpoint_layers:
+ - LlamaDecoderLayer
+
+# Refer to https://github.com/pytorch/xla/issues/6379 for backward optimization barrier info.
+optimization_barrier_layers:
+ - LlamaDecoderLayer
+
+sharding:
+  # Weights
+  model.embed_tokens.weight: [fsdp, null]
+  model.layers.*.self_attn.q_proj.weight: [fsdp, null]
+  model.layers.*.self_attn.k_proj.weight: [null, fsdp]
+  model.layers.*.self_attn.v_proj.weight: [null, fsdp]
+  model.layers.*.self_attn.o_proj.weight: [fsdp, null]
+  model.layers.*.mlp.gate_proj.weight: [fsdp, null]
+  model.layers.*.mlp.up_proj.weight: [fsdp, null]
+  model.layers.*.mlp.down_proj.weight: [null, fsdp]
+  model.layers.*.input_layernorm.weight: [fsdp]
+  model.layers.*.post_attention_layernorm.weight: [fsdp]
+  model.norm.weight: [fsdp]
+  lm_head.weight: [fsdp, null]
+
+  # Activations
+  model.layers.*: [fsdp, null, null]
+  lm_head: [fsdp, null, null]

--- a/torchprime/torch_xla_models/configs/model/scaling/mixtral-fsdp.yaml
+++ b/torchprime/torch_xla_models/configs/model/scaling/mixtral-fsdp.yaml
@@ -1,0 +1,26 @@
+activation_checkpoint_layers:
+ - MixtralDecoderLayer
+
+# Refer to https://github.com/pytorch/xla/issues/6379 for backward optimization barrier info.
+optimization_barrier_layers:
+ - MixtralDecoderLayer
+
+sharding:
+  # Weights
+  model.embed_tokens.weight: ['fsdp', null]
+  model.layers.*.self_attn.q_proj.weight: ['fsdp', null]
+  model.layers.*.self_attn.k_proj.weight: [null, 'fsdp']
+  model.layers.*.self_attn.v_proj.weight: [null, 'fsdp']
+  model.layers.*.self_attn.o_proj.weight: ['fsdp', null]
+  model.layers.*.block_sparse_moe.gate.weight: [null, 'fsdp']
+  model.layers.*.block_sparse_moe.experts.w1: [null, null, 'fsdp']
+  model.layers.*.block_sparse_moe.experts.w2: [null, 'fsdp', null]
+  model.layers.*.block_sparse_moe.experts.w3: [null, null, 'fsdp']
+  model.layers.*.input_layernorm.weight: ['fsdp']
+  model.layers.*.post_attention_layernorm.weight: ['fsdp']
+  model.norm.weight: ['fsdp']
+  lm_head.weight: ['fsdp', null]
+
+  # Activations
+  model.layers.*[0]: [fsdp, null, null]  # Shard the first output of the decoder layer
+  lm_head: [fsdp, null, null]

--- a/torchprime/torch_xla_models/loss.py
+++ b/torchprime/torch_xla_models/loss.py
@@ -1,0 +1,20 @@
+import torch
+from torch.nn import CrossEntropyLoss
+
+
+def cross_entropy_loss(logits: torch.Tensor, labels: torch.Tensor, vocab_size: int):
+  """
+  Computes cross entropy loss of `logits` against the ground truth `labels` during
+  next token prediction.
+
+  Useful as the loss function of a LLM in pretraining or supervised finetuning.
+  """
+  # Shift so that tokens < n predict n
+  shift_logits = logits[..., :-1, :].contiguous()
+  shift_labels = labels[..., 1:].contiguous()
+  # Flatten the tokens
+  loss_fct = CrossEntropyLoss()
+  shift_logits = shift_logits.view(-1, vocab_size)
+  shift_labels = shift_labels.view(-1)
+  shift_labels = shift_labels.to(shift_logits.device)
+  return loss_fct(shift_logits, shift_labels)

--- a/torchprime/torch_xla_models/tests/test_spmd.py
+++ b/torchprime/torch_xla_models/tests/test_spmd.py
@@ -1,0 +1,317 @@
+import copy
+import functools
+import unittest
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.distributed.spmd as xs
+from omegaconf import OmegaConf
+
+from torchprime.torch_xla_models.llama import LlamaForCausalLM
+from torchprime.torch_xla_models.llama.model import LlamaDecoderLayer
+from torchprime.torch_xla_models.mixtral import MixtralForCausalLM
+from torchprime.torch_xla_models.mixtral.model import MixtralDecoderLayer
+
+
+class TestConfigSpmd(unittest.TestCase):
+  """
+  Test that the config based sharder has identical behavior to FSDPv2.
+
+  Specifically:
+  - Model weights have the same sharding spec
+  - Outputs have the same sharding spec and are numerically close
+  - Gradients have the same sharding spec and are numerically close
+  """
+
+  @classmethod
+  def setUpClass(cls):
+    import torch_xla.runtime as xr
+
+    xr.use_spmd()
+
+    import jax
+
+    jax.config.update("jax_default_matmul_precision", "highest")
+    torch.set_default_dtype(torch.float32)
+    torch.manual_seed(42)
+    torch_xla.manual_seed(42)
+    torch_xla._XLAC._xla_set_mat_mul_precision("highest")
+
+  def test_llama_config_sharding_against_fsdp_v2(self):
+    import numpy as np
+    import torch_xla.runtime as xr
+    from torch_xla.distributed.spmd import Mesh
+
+    # TODO(https://github.com/pytorch/xla/issues/8063): `xla_force_host_platform_device_count` doesn't
+    # work on PyTorch/XLA. We must run this on the TPU for now.
+    if xr.device_type() != "TPU":
+      pytest.skip("This test only works on TPU")
+
+    super().setUp()
+    vocab_size = 128256
+    torchprime_config = OmegaConf.create(
+      {
+        "vocab_size": 128256,
+        "hidden_size": 4096,
+        "intermediate_size": 14336,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "hidden_act": "silu",
+        "max_position_embeddings": 131072,
+        "initializer_range": 0.02,
+        "rms_norm_eps": 1.0e-05,
+        "attention_dropout": False,
+        "attention_bias": False,
+        "flash_attention": True,
+        "rope_theta": 500000.0,
+      }
+    )
+    # Place model on CPU device first
+    with torch.device("cpu"):
+      model = LlamaForCausalLM(torchprime_config)
+
+    # Define mesh for test
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices, 1, 1)
+    assert num_devices > 1, "The TPU VM should have more than 1 device for SPMD testing"
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("dcn", "fsdp", "tensor", "expert"))
+    xs.set_global_mesh(mesh)
+
+    # Create random input and label of batch size 8, sequence length 256.
+    input = torch.randint(vocab_size, ((8, 256)), device=torch_xla.device())
+    xs.mark_sharding(input, mesh, ("fsdp", None))
+    labels = torch.randint(vocab_size, ((8, 256)), device=torch_xla.device())
+    xs.mark_sharding(labels, mesh, ("fsdp", None))
+    torch_xla.sync()
+
+    # Shard our model with config based sharding
+    sharding_config = {
+      # Weights
+      "model.embed_tokens.weight": ["fsdp", None],
+      "model.layers.*.self_attn.q_proj.weight": ["fsdp", None],
+      "model.layers.*.self_attn.k_proj.weight": [None, "fsdp"],
+      "model.layers.*.self_attn.v_proj.weight": [None, "fsdp"],
+      "model.layers.*.self_attn.o_proj.weight": ["fsdp", None],
+      "model.layers.*.mlp.gate_proj.weight": ["fsdp", None],
+      "model.layers.*.mlp.up_proj.weight": ["fsdp", None],
+      "model.layers.*.mlp.down_proj.weight": [None, "fsdp"],
+      "model.layers.*.input_layernorm.weight": ["fsdp"],
+      "model.layers.*.post_attention_layernorm.weight": ["fsdp"],
+      "model.norm.weight": ["fsdp"],
+      "lm_head.weight": ["fsdp", None],
+      # Activations
+      "model.layers.*": ["fsdp", None, None],
+      "lm_head": ["fsdp", None, None],
+    }
+    from torchprime.sharding.shard_model import shard_torch_xla_model_from_config
+
+    model_config_sharded = shard_torch_xla_model_from_config(
+      copy.deepcopy(model).to("xla"), config=sharding_config
+    )
+    torch_xla.sync()
+
+    # Shard model with FSDPv2
+    from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
+    from torch_xla.experimental.spmd_fully_sharded_data_parallel import (
+      SpmdFullyShardedDataParallel as FSDPv2,
+    )
+
+    auto_wrap_policy = functools.partial(
+      transformer_auto_wrap_policy,
+      # Transformer layer class to wrap
+      transformer_layer_cls={LlamaDecoderLayer},
+    )
+    model_fsdp_v2_sharded = FSDPv2(
+      copy.deepcopy(model),
+      shard_output=shard_output,
+      auto_wrap_policy=auto_wrap_policy,
+    )
+    torch_xla.sync()
+
+    assert_same_output_weights_grad(
+      model_config_sharded, model_fsdp_v2_sharded, input, labels
+    )
+
+  def test_mixtral_config_sharding_against_fsdp_v2(self):
+    import numpy as np
+    import torch_xla.runtime as xr
+    from torch_xla.distributed.spmd import Mesh
+
+    # TODO(https://github.com/pytorch/xla/issues/8063): `xla_force_host_platform_device_count` doesn't
+    # work on PyTorch/XLA. We must run this on the TPU for now.
+    if xr.device_type() != "TPU":
+      pytest.skip("This test only works on TPU")
+
+    super().setUp()
+    vocab_size = 32000
+    torchprime_config = OmegaConf.create(
+      {
+        "vocab_size": vocab_size,
+        "hidden_size": 4096,
+        "initializer_range": 0.02,
+        "intermediate_size": 14336,
+        "num_hidden_layers": 2,
+        "max_position_embeddings": 32768,
+        "num_attention_heads": 32,
+        "num_experts_per_tok": 2,
+        "num_key_value_heads": 8,
+        "num_local_experts": 8,
+        "rms_norm_eps": 1e-05,
+        "rope_theta": 1000000.0,
+        "router_aux_loss_coef": 0.02,
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "flash_attention": True,
+        "moe_implementation": "gmm",
+      }
+    )
+    # Place model on CPU device first
+    with torch.device("cpu"):
+      model = MixtralForCausalLM(torchprime_config)
+
+    # Define mesh for test
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices, 1, 1)
+    assert num_devices > 1, "The TPU VM should have more than 1 device for SPMD testing"
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("dcn", "fsdp", "tensor", "expert"))
+    xs.set_global_mesh(mesh)
+
+    # Create random input and label of batch size 8, sequence length 256.
+    input = torch.randint(vocab_size, ((8, 256)), device=torch_xla.device())
+    xs.mark_sharding(input, mesh, ("fsdp", None))
+    labels = torch.randint(vocab_size, ((8, 256)), device=torch_xla.device())
+    xs.mark_sharding(labels, mesh, ("fsdp", None))
+    torch_xla.sync()
+
+    # Shard our model with config based sharding
+    sharding_config = {
+      # Weights
+      "model.embed_tokens.weight": ["fsdp", None],
+      "model.layers.*.self_attn.q_proj.weight": ["fsdp", None],
+      "model.layers.*.self_attn.k_proj.weight": [None, "fsdp"],
+      "model.layers.*.self_attn.v_proj.weight": [None, "fsdp"],
+      "model.layers.*.self_attn.o_proj.weight": ["fsdp", None],
+      "model.layers.*.block_sparse_moe.gate.weight": [None, "fsdp"],
+      "model.layers.*.block_sparse_moe.experts.w1": [None, None, "fsdp"],
+      "model.layers.*.block_sparse_moe.experts.w2": [None, "fsdp", None],
+      "model.layers.*.block_sparse_moe.experts.w3": [None, None, "fsdp"],
+      "model.layers.*.input_layernorm.weight": ["fsdp"],
+      "model.layers.*.post_attention_layernorm.weight": ["fsdp"],
+      "model.norm.weight": ["fsdp"],
+      "lm_head.weight": ["fsdp", None],
+      # Activations
+      # Shard the first element of decoder output
+      "model.layers.*[0]": ["fsdp", None, None],
+      "lm_head": ["fsdp", None, None],
+    }
+    from torchprime.sharding.shard_model import shard_torch_xla_model_from_config
+
+    model_config_sharded = shard_torch_xla_model_from_config(
+      copy.deepcopy(model).to("xla"), config=sharding_config
+    )
+    torch_xla.sync()
+
+    # Shard model with FSDPv2
+    from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
+    from torch_xla.experimental.spmd_fully_sharded_data_parallel import (
+      SpmdFullyShardedDataParallel as FSDPv2,
+    )
+
+    auto_wrap_policy = functools.partial(
+      transformer_auto_wrap_policy,
+      # Transformer layer class to wrap
+      transformer_layer_cls={MixtralDecoderLayer},
+    )
+    model_fsdp_v2_sharded = FSDPv2(
+      copy.deepcopy(model),
+      shard_output=shard_output,
+      auto_wrap_policy=auto_wrap_policy,
+    )
+    torch_xla.sync()
+
+    assert_same_output_weights_grad(
+      model_config_sharded, model_fsdp_v2_sharded, input, labels
+    )
+
+
+def assert_same_output_weights_grad(
+  model_config_sharded, model_fsdp_v2_sharded, input, labels
+):
+  """
+  Asserts that two models have the same output, weights, and gradients, in terms of
+  numerics and sharding specs.
+  """
+  # Run the model and backwards
+  config_logits, config_loss = model_config_sharded(
+    input, labels=labels, attention_mask=torch.ones_like(input)
+  )
+  config_loss.backward()
+  torch_xla.sync()
+
+  fsdp_logits, fsdp_loss = model_fsdp_v2_sharded(
+    input, labels=labels, attention_mask=torch.ones_like(input)
+  )
+  fsdp_loss.backward()
+  torch_xla.sync()
+
+  # Check sharding and numeric accuracy.
+  assert_same_value_and_sharding(
+    config_logits,
+    fsdp_logits,
+    msg="Config sharded and FSDP v2 sharded logits are not equal",
+  )
+  assert_same_value_and_sharding(
+    config_loss,
+    fsdp_loss,
+    msg="Config sharded and FSDP v2 sharded loss are not equal",
+  )
+
+  # Check model weights and gradients.
+  for (p1_name, p1), (p2_name, p2) in zip(
+    model_config_sharded.named_parameters(),
+    model_fsdp_v2_sharded.named_parameters(),
+    strict=True,
+  ):
+    # Because both config sharding and FSDPv2 adds wrapper modules, the module
+    # tree might be different. we should at least assert that the last name
+    # component matches.
+    assert p1_name.split(".")[-1] == p2_name.split(".")[-1]
+    assert_same_value_and_sharding(p1, p2, msg=f"{p1_name} and {p2_name} are not equal")
+
+    assert p1.grad is not None
+    assert p2.grad is not None
+    assert_same_value_and_sharding(
+      p1.grad,
+      p2.grad,
+      msg="Config sharded and FSDP v2 sharded gradients are not equal",
+    )
+
+
+def assert_same_value_and_sharding(actual, expected, msg):
+  torch.testing.assert_close(
+    actual.cpu(),
+    expected.cpu(),
+    msg=msg,
+  )
+  actual_sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(actual)
+  expected_sharding_spec = torch_xla._XLAC._get_xla_sharding_spec(expected)
+  assert actual_sharding_spec == expected_sharding_spec
+
+
+def shard_output(output, mesh):
+  real_output = None
+  if isinstance(output, torch.Tensor):
+    real_output = output
+  elif isinstance(output, tuple):
+    real_output = output[0]
+  else:
+    raise RuntimeError("Unsupported")
+  xs.mark_sharding(real_output, mesh, ("fsdp", None, None))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
This PR replaces FSDPv2 and hardcoded sharding specs with sharding config files.

Tests:

- Added a test that compares FSDPv2 and config based sharder numerics and sharding specs for a 2 layer Llama and 2 layer Mixtral.
- I compared the loss curve and running time for Llama on v6e-8, and Mixtral on v6e-8.
- I also compared them on a Trillium pod on xpk.

## Llama

Llama FSDPv2:

```
 - Step: 0, loss: 12.5718, trace time: 134588.13 ms
 - Step: 10, loss: 10.9212, trace time: 878.29 ms
 - Step: 20, loss: 9.1416, trace time: 880.09 ms
 - Step: 30, loss: 8.2824, trace time: 878.94 ms
 - Step: 40, loss: 7.0730, trace time: 883.22 ms
 - Step: 50, loss: 6.8937, trace time: 862.05 ms
 - Step: 60, loss: 6.9061, trace time: 857.86 ms
 - Step: 70, loss: 6.8793, trace time: 874.83 ms
 - Step: 80, loss: 6.8040, trace time: 145796.24 ms
 - Step: 90, loss: 6.7863, trace time: 913.06 ms
 - Finished training run
 - Step duration: 3.695 s
```

Llama Config based:

```
 - Step: 0, loss: 12.5718, trace time: 119801.30 ms
 - Step: 10, loss: 10.9285, trace time: 982.66 ms
 - Step: 20, loss: 9.2224, trace time: 961.95 ms
 - Step: 30, loss: 7.4156, trace time: 979.38 ms
 - Step: 40, loss: 6.9384, trace time: 974.15 ms
 - Step: 50, loss: 6.8775, trace time: 952.50 ms
 - Step: 60, loss: 6.8922, trace time: 963.18 ms
 - Step: 70, loss: 6.8683, trace time: 938.67 ms
 - Step: 80, loss: 6.7947, trace time: 115190.57 ms
 - Step: 90, loss: 6.7745, trace time: 984.25 ms
 - Finished training run
 - Step duration: 3.703 s
```

The delta in loss and step time is ~0.2%. The are not identical despite the identical sharding. Therefore, I also trained this on a v4-8 and the loss numbers also changes quite a bit, so this should be within acceptible noise interval.

For reference, FSDPv2 on v4-8 curve looks like this:

```
 - Step: 0, loss: 12.5720, trace time: 123530.85 ms
 - Step: 10, loss: 11.5086, trace time: 1688.35 ms
 - Step: 20, loss: 9.5840, trace time: 1726.88 ms
 - Step: 30, loss: 8.7745, trace time: 1757.86 ms
 - Step: 40, loss: 7.1194, trace time: 1740.76 ms
 - Step: 50, loss: 6.9021, trace time: 1717.90 ms
 - Step: 60, loss: 6.9035, trace time: 2015.98 ms
 - Step: 70, loss: 6.8790, trace time: 1973.11 ms
 - Step: 80, loss: 6.8034, trace time: 130805.92 ms
 - Step: 90, loss: 6.7861, trace time: 1738.55 ms
```

This suggests to me that the loss delta is acceptable.

I also ran Llama 3-8B on xpk and got the same step time as https://github.com/AI-Hypercomputer/torchprime/issues/16#issuecomment-2638386904.

## Mixtral

Mixtral 8x7B with FSDPv2:

```
 - Step: 0, loss: 11.1757, trace time: 440648.42 ms
 - Step: 10, loss: 10.4170, trace time: 9153.15 ms
 - Step: 20, loss: 8.5687, trace time: 9129.96 ms
 - Step: 30, loss: 7.6070, trace time: 9858.94 ms
 - Step: 40, loss: 7.1508, trace time: 9779.03 ms
 - Step: 50, loss: 7.0312, trace time: 9774.99 ms
 - Step: 60, loss: 6.9317, trace time: 9829.54 ms
 - Step: 70, loss: 6.7952, trace time: 9976.81 ms
 - Step: 80, loss: 6.6540, trace time: 450864.63 ms
 - Step: 90, loss: 6.6430, trace time: 9370.79 ms
 - Finished training run
 - Step duration: 10.001 s
```

Mixtral 8x7B with config sharding:

```
 - Step: 0, loss: 11.1757, trace time: 413730.83 ms
 - Step: 10, loss: 10.4113, trace time: 3784.12 ms
 - Step: 20, loss: 8.0267, trace time: 3779.08 ms
 - Step: 30, loss: 7.2595, trace time: 3821.59 ms
 - Step: 40, loss: 7.1256, trace time: 3824.65 ms
 - Step: 50, loss: 7.2663, trace time: 3515.31 ms
 - Step: 60, loss: 6.8813, trace time: 3360.15 ms
 - Step: 70, loss: 6.7367, trace time: 3341.72 ms
 - Step: 80, loss: 6.6374, trace time: 432356.79 ms
 - Step: 90, loss: 6.6372, trace time: 3431.99 ms
 - Finished training run
 - Step duration: 9.951 s
```

The delta is similar to Llama.

I also ran Mixtral 8x7B on xpk and got similar step time as a run from the main branch (using FSDPv2) using pdbs=2:

- FSDPv2: 8.144 s
- Config based: 8.153 s
- Delta: ~0.1%

Fixes #21.