### PR TITLE
End-to-end tests for torch_xla llama and mixtral

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,3 +65,6 @@ htmlcov/
 
 # torchprime config
 .config
+
+# Google cloud credentials generated during CI
+gha-creds-*.json

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -1,0 +1,71 @@
+name: E2E setup
+description: Setup torchprime, docker, and gcloud for E2E tests
+inputs:
+  gcp_project:
+    required: true
+    type: string
+  gcp_zone:
+    required: true
+    type: string
+  xpk_cluster_name:
+    required: true
+    type: string
+  tpu_type:
+    required: true
+    type: string
+  artifact_dir:
+    required: true
+    type: string
+  gcp_sa_key:
+    description: GCP service account key
+    required: true
+    type: string
+runs:
+  using: "composite"
+  steps:
+    - name: Use Docker in rootless mode
+      uses: ScribeMD/rootless-docker@0.2.2
+    - name: Add user to docker group
+      run: |
+        sudo usermod -aG docker $USER
+        newgrp docker
+      shell: bash
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[dev]'
+      shell: bash
+    # Googlers: if this fails, follow http://shortn/_61iSj31q1b to debug.
+    - uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ inputs.gcp_sa_key }}'
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '>= 363.0.0'
+        install_components: 'beta,gke-gcloud-auth-plugin'
+    - name: Verify GCP setup
+      run: gcloud info
+      shell: bash
+    - name: Authenticate Docker
+      run: gcloud auth configure-docker --quiet
+      shell: bash
+    - name: Activate SA credentials
+      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+      shell: bash
+    - name: tp doctor
+      run: tp doctor
+      shell: bash
+    - name: tp use
+      run: >
+        tp use
+        --project '${{ inputs.gcp_project }}'
+        --zone '${{ inputs.gcp_zone }}'
+        --cluster '${{ inputs.xpk_cluster_name }}'
+        --num-slices 1
+        --artifact-dir '${{ inputs.artifact_dir }}'
+        --tpu-type '${{ inputs.tpu_type }}'
+      shell: bash

--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
+  schedule:  # Schedule the job run at 12AM PST daily.
   - cron: "0 8 * * *"
 
 jobs:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,273 @@
+name: E2E tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:  # Schedule the job run at 12AM PST daily.
+  - cron: "0 8 * * *"
+
+# Note:
+# v6e cluster used: http://shortn/_oswg6PyPo6
+# If we migrate to another project, these configs should be updated accordingly.
+env:
+  XPK_CLUSTER_NAME: tpu-v6e-ci
+  GCP_PROJECT: tpu-pytorch
+  GCP_ZONE: us-central2
+  TPU_TYPE: v6e-4
+
+jobs:
+  tp-run:
+    name: Train models via 'tp run'
+    runs-on: [ubuntu-22.04]
+    env:
+      ARTIFACT_DIR: gs://torchprime-e2e-tests/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}
+      RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+    outputs:
+      llama-3-8b-name: ${{ steps.run-llama-3-8b.outputs.name }}
+      mixtral-8x7b-name: ${{ steps.run-mixtral-8x7b.outputs.name }}
+      artifact-dir: ${{ steps.artifacts.outputs.artifact_dir }}
+    steps:
+    - name: Record artifact dir
+      id: artifacts
+      run: |
+        echo "Artifact dir: $ARTIFACT_DIR"
+        echo "artifact_dir=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@v4.1
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+    - name: Use Docker in rootless mode
+      uses: ScribeMD/rootless-docker@0.2.2
+    - name: Add user to docker group
+      run: |
+        sudo usermod -aG docker $USER
+        newgrp docker
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[dev]'
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        # Googlers: if this fails, follow http://shortn/_61iSj31q1b to debug.
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '>= 363.0.0'
+        install_components: 'beta,gke-gcloud-auth-plugin'
+    - name: Verify gcp setup
+      run: gcloud info
+    - name: Authenticate Docker
+      run: gcloud auth configure-docker --quiet
+    - name: Activate SA credentials
+      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+    - name: tp doctor
+      run: tp doctor
+    - name: tp use
+      run: >
+        tp use
+        --project $GCP_PROJECT
+        --zone $GCP_ZONE
+        --cluster $XPK_CLUSTER_NAME
+        --num-slices 1
+        --artifact-dir $ARTIFACT_DIR
+        --tpu-type $TPU_TYPE
+    - name: Run Llama 3.0 8B
+      id: run-llama-3-8b
+      env:
+        # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/14): Remove and burn the token.
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        XLA_IR_DEBUG: 1
+        XLA_HLO_DEBUG: 1
+      run: |
+        random_id=$(cat /dev/urandom | tr -dc a-z0-9 | head -c 8)
+        name="llama-3-8b-$random_id"
+
+        tp run \
+          --name $name \
+          torchprime/torch_xla_models/train.py \
+          model=llama-3-8b \
+          global_batch_size=8 \
+          mesh.fsdp=4 \
+          dataset_config_name=wikitext-2-raw-v1 \
+          profile_step=3 \
+          max_steps=15
+
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Run Mixtral 8x7B
+      id: run-mixtral-8x7b
+      env:
+        # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/14): Remove and burn the token.
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        XLA_IR_DEBUG: 1
+        XLA_HLO_DEBUG: 1
+      run: |
+        random_id=$(cat /dev/urandom | tr -dc a-z0-9 | head -c 8)
+        name="mixtral-8x7b-$random_id"
+
+        # Run 16 instead of 32 decoder layers to fit on v6e-4.
+        tp run \
+          --name $name \
+          torchprime/torch_xla_models/train.py \
+          model=mixtral-8x7b \
+          model.num_hidden_layers=16 \
+          global_batch_size=8 \
+          mesh.fsdp=4 \
+          dataset_config_name=wikitext-2-raw-v1 \
+          profile_step=3 \
+          max_steps=15
+
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+  llama-3-8b:
+    name: Check Llama 3.0 8B
+    needs: tp-run
+    runs-on: [ubuntu-22.04]
+    env:
+      ARTIFACT_DIR: ${{needs.tp-run.outputs.artifact-dir}}
+      JOBSET_NAME: ${{needs.tp-run.outputs.llama-3-8b-name}}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[dev]'
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '>= 363.0.0'
+        install_components: 'beta,gke-gcloud-auth-plugin'
+    - name: Verify gcp setup
+      run: gcloud info
+    - name: Authenticate Docker
+      run: gcloud auth configure-docker --quiet
+    - name: Activate SA credentials
+      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+    - name: tp use
+      run: >
+        tp use
+        --project $GCP_PROJECT
+        --zone $GCP_ZONE
+        --cluster $XPK_CLUSTER_NAME
+        --num-slices 1
+        --artifact-dir $ARTIFACT_DIR
+        --tpu-type $TPU_TYPE
+    - name: Get GKE credentials
+      run: |
+        gcloud container clusters get-credentials $XPK_CLUSTER_NAME --region=$GCP_ZONE --project=$GCP_PROJECT
+        kubectl config view
+        kubectl config set-context --current --namespace=default
+    - name: Stream logs
+      run: |
+        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
+        kubectl logs -c jax-tpu -f $pod_name | tee /tmp/pod-$pod_name.log
+    - name: Check workload state
+      run: xpk workload list --cluster $XPK_CLUSTER_NAME --wait-for-job-completion=$JOBSET_NAME
+    - name: Check logs
+      run: |
+        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
+        if ! grep -q "Step duration:.*s" /tmp/pod-$pod_name.log; then
+          echo "Error: 'Step duration' not found in logs"
+          exit 1
+        fi
+        if ! grep -q "Finished training run" /tmp/pod-$pod_name.log; then
+          echo "Error: 'Finished training run' not found in logs"
+          exit 1
+        fi
+    - name: Check that profile is taken
+      run: |
+        profile_dir="$ARTIFACT_DIR/$JOBSET_NAME/profile/0-0"
+        gcloud storage ls -r "$profile_dir/**/*.xplane.pb" | grep -c .xplane.pb | grep "^1$"
+        if [[ $? -ne 0 ]]; then
+          echo "Error: Expected exactly one .xplane.pb file in $profile_dir:"
+          gcloud storage ls -r "$profile_dir/**/*.xplane.pb"
+          exit 1
+        fi
+    # TODO: delete workload
+    # xpk workload delete --workload xpk-test-workload --cluster xpk-test
+  mixtral-8x7b:
+    name: Check Mixtral 8x7B
+    needs: tp-run
+    runs-on: [ubuntu-22.04]
+    env:
+      ARTIFACT_DIR: ${{needs.tp-run.outputs.artifact-dir}}
+      JOBSET_NAME: ${{needs.tp-run.outputs.mixtral-8x7b-name}}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[dev]'
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '>= 363.0.0'
+        install_components: 'beta,gke-gcloud-auth-plugin'
+    - name: Verify gcp setup
+      run: gcloud info
+    - name: Authenticate Docker
+      run: gcloud auth configure-docker --quiet
+    - name: Activate SA credentials
+      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+    - name: tp use
+      run: >
+        tp use
+        --project $GCP_PROJECT
+        --zone $GCP_ZONE
+        --cluster $XPK_CLUSTER_NAME
+        --num-slices 1
+        --artifact-dir $ARTIFACT_DIR
+        --tpu-type $TPU_TYPE
+    - name: Get GKE credentials
+      run: |
+        gcloud container clusters get-credentials $XPK_CLUSTER_NAME --region=$GCP_ZONE --project=$GCP_PROJECT
+        kubectl config view
+        kubectl config set-context --current --namespace=default
+    - name: Stream logs
+      run: |
+        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
+        kubectl logs -c jax-tpu -f $pod_name | tee /tmp/pod-$pod_name.log
+    - name: Check workload state
+      run: xpk workload list --cluster $XPK_CLUSTER_NAME --wait-for-job-completion=$JOBSET_NAME
+    - name: Check logs
+      run: |
+        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
+        if ! grep -q "Step duration:.*s" /tmp/pod-$pod_name.log; then
+          echo "Error: 'Step duration' not found in logs"
+          exit 1
+        fi
+        if ! grep -q "Finished training run" /tmp/pod-$pod_name.log; then
+          echo "Error: 'Finished training run' not found in logs"
+          exit 1
+        fi
+    - name: Check that profile is taken
+      run: |
+        profile_dir="$ARTIFACT_DIR/$JOBSET_NAME/profile/0-0"
+        gcloud storage ls -r "$profile_dir/**/*.xplane.pb" | grep -c .xplane.pb | grep "^1$"
+        if [[ $? -ne 0 ]]; then
+          echo "Error: Expected exactly one .xplane.pb file in $profile_dir:"
+          gcloud storage ls -r "$profile_dir/**/*.xplane.pb"
+          exit 1
+        fi
+    # TODO: delete workload
+    # xpk workload delete --workload xpk-test-workload --cluster xpk-test

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -5,269 +5,95 @@ on:
     branches:
       - main
   pull_request:
-  schedule:  # Schedule the job run at 12AM PST daily.
-  - cron: "0 8 * * *"
-
-# Note:
-# v6e cluster used: http://shortn/_oswg6PyPo6
-# If we migrate to another project, these configs should be updated accordingly.
-env:
-  XPK_CLUSTER_NAME: tpu-v6e-ci
-  GCP_PROJECT: tpu-pytorch
-  GCP_ZONE: us-central2
-  TPU_TYPE: v6e-4
+  schedule:
+    - cron: "0 8 * * *"  # Run daily at 12AM PST (adjusted for UTC)
 
 jobs:
   tp-run:
-    name: Train models via 'tp run'
-    runs-on: [ubuntu-22.04]
+    name: Submit workloads
+    runs-on: ubuntu-22.04
     env:
       ARTIFACT_DIR: gs://torchprime-e2e-tests/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}
-      RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       llama-3-8b-name: ${{ steps.run-llama-3-8b.outputs.name }}
       mixtral-8x7b-name: ${{ steps.run-mixtral-8x7b.outputs.name }}
       artifact-dir: ${{ steps.artifacts.outputs.artifact_dir }}
     steps:
-    - name: Record artifact dir
-      id: artifacts
-      run: |
-        echo "Artifact dir: $ARTIFACT_DIR"
-        echo "artifact_dir=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
-    - name: Maximize build space
-      uses: AdityaGarg8/remove-unwanted-software@v4.1
-      with:
-        remove-dotnet: 'true'
-        remove-android: 'true'
-        remove-haskell: 'true'
-        remove-codeql: 'true'
-    - name: Use Docker in rootless mode
-      uses: ScribeMD/rootless-docker@0.2.2
-    - name: Add user to docker group
-      run: |
-        sudo usermod -aG docker $USER
-        newgrp docker
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        cache: 'pip'
-    - name: Install dev dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[dev]'
-    - uses: 'google-github-actions/auth@v2'
-      with:
-        # Googlers: if this fails, follow http://shortn/_61iSj31q1b to debug.
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
-    - uses: google-github-actions/setup-gcloud@v2
-      with:
-        version: '>= 363.0.0'
-        install_components: 'beta,gke-gcloud-auth-plugin'
-    - name: Verify gcp setup
-      run: gcloud info
-    - name: Authenticate Docker
-      run: gcloud auth configure-docker --quiet
-    - name: Activate SA credentials
-      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    - name: tp doctor
-      run: tp doctor
-    - name: tp use
-      run: >
-        tp use
-        --project $GCP_PROJECT
-        --zone $GCP_ZONE
-        --cluster $XPK_CLUSTER_NAME
-        --num-slices 1
-        --artifact-dir $ARTIFACT_DIR
-        --tpu-type $TPU_TYPE
-    - name: Run Llama 3.0 8B
-      id: run-llama-3-8b
-      env:
-        # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/14): Remove and burn the token.
-        HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        XLA_IR_DEBUG: 1
-        XLA_HLO_DEBUG: 1
-      run: |
-        random_id=$(cat /dev/urandom | tr -dc a-z0-9 | head -c 8)
-        name="llama-3-8b-$random_id"
+      - name: Record artifact dir
+        id: artifacts
+        run: |
+          echo "Artifact dir: $ARTIFACT_DIR"
+          echo "artifact_dir=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v4.1
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/e2e-setup
+        with:
+          gcp_project: ${{ vars.GCP_PROJECT }}
+          gcp_zone: ${{ vars.GCP_ZONE }}
+          xpk_cluster_name: ${{ vars.XPK_CLUSTER_NAME }}
+          tpu_type: ${{ vars.TPU_TYPE }}
+          artifact_dir: ${{ env.ARTIFACT_DIR }}
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
 
-        tp run \
-          --name $name \
-          torchprime/torch_xla_models/train.py \
-          model=llama-3-8b \
-          global_batch_size=8 \
-          mesh.fsdp=4 \
-          dataset_config_name=wikitext-2-raw-v1 \
-          profile_step=3 \
-          max_steps=15
+      - name: Run Llama 3.0 8B
+        id: run-llama-3-8b
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          XLA_IR_DEBUG: 1
+          XLA_HLO_DEBUG: 1
+        run: |
+          name=$(e2e_testing/gen_name.py llama-3-8b)
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          tp run \
+            --name $name \
+            torchprime/torch_xla_models/train.py \
+            model=llama-3-8b \
+            global_batch_size=8 \
+            mesh.fsdp=4 \
+            dataset_config_name=wikitext-2-raw-v1 \
+            profile_step=3 \
+            max_steps=15
 
-        echo "name=$name" >> "$GITHUB_OUTPUT"
-    - name: Run Mixtral 8x7B
-      id: run-mixtral-8x7b
-      env:
-        # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/14): Remove and burn the token.
-        HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        XLA_IR_DEBUG: 1
-        XLA_HLO_DEBUG: 1
-      run: |
-        random_id=$(cat /dev/urandom | tr -dc a-z0-9 | head -c 8)
-        name="mixtral-8x7b-$random_id"
+      - name: Run Mixtral 8x7B
+        id: run-mixtral-8x7b
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          XLA_IR_DEBUG: 1
+          XLA_HLO_DEBUG: 1
+        run: |
+          name=$(e2e_testing/gen_name.py mixtral-8x7b)
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          tp run \
+            --name $name \
+            torchprime/torch_xla_models/train.py \
+            model=mixtral-8x7b \
+            model.num_hidden_layers=16 \
+            global_batch_size=8 \
+            mesh.fsdp=4 \
+            dataset_config_name=wikitext-2-raw-v1 \
+            profile_step=3 \
+            max_steps=15
 
-        # Run 16 instead of 32 decoder layers to fit on v6e-4.
-        tp run \
-          --name $name \
-          torchprime/torch_xla_models/train.py \
-          model=mixtral-8x7b \
-          model.num_hidden_layers=16 \
-          global_batch_size=8 \
-          mesh.fsdp=4 \
-          dataset_config_name=wikitext-2-raw-v1 \
-          profile_step=3 \
-          max_steps=15
-
-        echo "name=$name" >> "$GITHUB_OUTPUT"
   llama-3-8b:
-    name: Check Llama 3.0 8B
+    name: Llama 3.0 8B
     needs: tp-run
-    runs-on: [ubuntu-22.04]
-    env:
-      ARTIFACT_DIR: ${{needs.tp-run.outputs.artifact-dir}}
-      JOBSET_NAME: ${{needs.tp-run.outputs.llama-3-8b-name}}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        cache: 'pip'
-    - name: Install dev dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[dev]'
-    - uses: 'google-github-actions/auth@v2'
-      with:
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
-    - uses: google-github-actions/setup-gcloud@v2
-      with:
-        version: '>= 363.0.0'
-        install_components: 'beta,gke-gcloud-auth-plugin'
-    - name: Verify gcp setup
-      run: gcloud info
-    - name: Authenticate Docker
-      run: gcloud auth configure-docker --quiet
-    - name: Activate SA credentials
-      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    - name: tp use
-      run: >
-        tp use
-        --project $GCP_PROJECT
-        --zone $GCP_ZONE
-        --cluster $XPK_CLUSTER_NAME
-        --num-slices 1
-        --artifact-dir $ARTIFACT_DIR
-        --tpu-type $TPU_TYPE
-    - name: Get GKE credentials
-      run: |
-        gcloud container clusters get-credentials $XPK_CLUSTER_NAME --region=$GCP_ZONE --project=$GCP_PROJECT
-        kubectl config view
-        kubectl config set-context --current --namespace=default
-    - name: Stream logs
-      run: |
-        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
-        kubectl logs -c jax-tpu -f $pod_name | tee /tmp/pod-$pod_name.log
-    - name: Check workload state
-      run: xpk workload list --cluster $XPK_CLUSTER_NAME --wait-for-job-completion=$JOBSET_NAME
-    - name: Check logs
-      run: |
-        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
-        if ! grep -q "Step duration:.*s" /tmp/pod-$pod_name.log; then
-          echo "Error: 'Step duration' not found in logs"
-          exit 1
-        fi
-        if ! grep -q "Finished training run" /tmp/pod-$pod_name.log; then
-          echo "Error: 'Finished training run' not found in logs"
-          exit 1
-        fi
-    - name: Check that profile is taken
-      run: |
-        profile_dir="$ARTIFACT_DIR/$JOBSET_NAME/profile/0-0"
-        gcloud storage ls -r "$profile_dir/**/*.xplane.pb" | grep -c .xplane.pb | grep "^1$"
-        if [[ $? -ne 0 ]]; then
-          echo "Error: Expected exactly one .xplane.pb file in $profile_dir:"
-          gcloud storage ls -r "$profile_dir/**/*.xplane.pb"
-          exit 1
-        fi
-    # TODO: delete workload
-    # xpk workload delete --workload xpk-test-workload --cluster xpk-test
+    uses: ./.github/workflows/reusable_e2e_check.yml
+    with:
+      jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-name }}
+      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
+    secrets: inherit
+
   mixtral-8x7b:
-    name: Check Mixtral 8x7B
+    name: Mixtral 8x7B
     needs: tp-run
-    runs-on: [ubuntu-22.04]
-    env:
-      ARTIFACT_DIR: ${{needs.tp-run.outputs.artifact-dir}}
-      JOBSET_NAME: ${{needs.tp-run.outputs.mixtral-8x7b-name}}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        cache: 'pip'
-    - name: Install dev dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[dev]'
-    - uses: 'google-github-actions/auth@v2'
-      with:
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
-    - uses: google-github-actions/setup-gcloud@v2
-      with:
-        version: '>= 363.0.0'
-        install_components: 'beta,gke-gcloud-auth-plugin'
-    - name: Verify gcp setup
-      run: gcloud info
-    - name: Authenticate Docker
-      run: gcloud auth configure-docker --quiet
-    - name: Activate SA credentials
-      run: gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    - name: tp use
-      run: >
-        tp use
-        --project $GCP_PROJECT
-        --zone $GCP_ZONE
-        --cluster $XPK_CLUSTER_NAME
-        --num-slices 1
-        --artifact-dir $ARTIFACT_DIR
-        --tpu-type $TPU_TYPE
-    - name: Get GKE credentials
-      run: |
-        gcloud container clusters get-credentials $XPK_CLUSTER_NAME --region=$GCP_ZONE --project=$GCP_PROJECT
-        kubectl config view
-        kubectl config set-context --current --namespace=default
-    - name: Stream logs
-      run: |
-        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
-        kubectl logs -c jax-tpu -f $pod_name | tee /tmp/pod-$pod_name.log
-    - name: Check workload state
-      run: xpk workload list --cluster $XPK_CLUSTER_NAME --wait-for-job-completion=$JOBSET_NAME
-    - name: Check logs
-      run: |
-        pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=$JOBSET_NAME -o json | jq --raw-output '.items[0].metadata.name')
-        if ! grep -q "Step duration:.*s" /tmp/pod-$pod_name.log; then
-          echo "Error: 'Step duration' not found in logs"
-          exit 1
-        fi
-        if ! grep -q "Finished training run" /tmp/pod-$pod_name.log; then
-          echo "Error: 'Finished training run' not found in logs"
-          exit 1
-        fi
-    - name: Check that profile is taken
-      run: |
-        profile_dir="$ARTIFACT_DIR/$JOBSET_NAME/profile/0-0"
-        gcloud storage ls -r "$profile_dir/**/*.xplane.pb" | grep -c .xplane.pb | grep "^1$"
-        if [[ $? -ne 0 ]]; then
-          echo "Error: Expected exactly one .xplane.pb file in $profile_dir:"
-          gcloud storage ls -r "$profile_dir/**/*.xplane.pb"
-          exit 1
-        fi
-    # TODO: delete workload
-    # xpk workload delete --workload xpk-test-workload --cluster xpk-test
+    uses: ./.github/workflows/reusable_e2e_check.yml
+    with:
+      jobset_name: ${{ needs.tp-run.outputs.mixtral-8x7b-name }}
+      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
+    secrets: inherit

--- a/.github/workflows/reusable_e2e_check.yml
+++ b/.github/workflows/reusable_e2e_check.yml
@@ -1,0 +1,54 @@
+name: Reusable E2E Check Workflow
+
+on:
+  workflow_call:
+    inputs:
+      jobset_name:
+        description: "The jobset name to check (e.g. llama-3-8b-XXXX)"
+        required: true
+        type: string
+      artifact_dir:
+        description: "GCS artifact directory to use for the run"
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        required: true
+      # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/14): Remove and burn the token.
+      HF_TOKEN:
+        required: true
+
+jobs:
+  results:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/e2e-setup
+        with:
+          gcp_project: ${{ vars.GCP_PROJECT }}
+          gcp_zone: ${{ vars.GCP_ZONE }}
+          xpk_cluster_name: ${{ vars.XPK_CLUSTER_NAME }}
+          tpu_type: ${{ vars.TPU_TYPE }}
+          artifact_dir: ${{ inputs.artifact_dir }}
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Get GKE credentials
+        run: |
+          gcloud container clusters get-credentials ${{ vars.XPK_CLUSTER_NAME }} --region=${{ vars.GCP_ZONE }} --project=${{ vars.GCP_PROJECT }}
+          kubectl config view
+          kubectl config set-context --current --namespace=default
+      - name: Stream logs
+        run: |
+          pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=${{ inputs.jobset_name }} -o json | jq --raw-output '.items[0].metadata.name')
+          # Save logs to a file for later checks
+          kubectl logs -c jax-tpu -f $pod_name | tee /tmp/pod-$pod_name.log
+      - name: Wait for workload to complete
+        run: |
+          xpk workload list --cluster ${{ vars.XPK_CLUSTER_NAME }} --wait-for-job-completion=${{ inputs.jobset_name }}
+      - name: Validate logs
+        run: |
+          pod_name=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=${{ inputs.jobset_name }} -o json | jq --raw-output '.items[0].metadata.name')
+          e2e_testing/check_logs.py /tmp/pod-$pod_name.log
+      - name: Validate profile
+        run: |
+          profile_dir="${{ inputs.artifact_dir }}/${{ inputs.jobset_name }}/profile/0-0"
+          e2e_testing/check_profile.py "$profile_dir"

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ htmlcov/
 
 # torchprime config
 .config
+
+# Google cloud credentials generated during CI
+gha-creds-*.json

--- a/e2e_testing/README.md
+++ b/e2e_testing/README.md
@@ -3,4 +3,23 @@
 These scripts are used during the [E2E test][e2e-test] GitHub action to run some
 models and validate the results.
 
+## E2E test design
+
+The workflows in [e2e_test.yml][e2e-test] does a few things:
+
+- Set up `gcloud` credentials from a Service Account key managed in repo secrets.
+- Install `torchprime`.
+- Test `tp use` and point it to an XPK cluster hosted internally.
+- Test `tp run` on a few models.
+
+After kicking off the training of some models, it starts a parallel job for each
+model, and runs a few checks. This is implemented in
+[reusable_e2e_check.yml][e2e-check]:
+
+- Stream the logs.
+- Check workload exit code.
+- Check for specific log strings that indicate training success.
+- Check that there is a profile `.pb` file.
+
 [e2e-test]: /.github/workflows/e2e_test.yml
+[e2e-check]: /.github/workflows/reusable_e2e_check.yml

--- a/e2e_testing/README.md
+++ b/e2e_testing/README.md
@@ -1,0 +1,6 @@
+# E2E testing
+
+These scripts are used during the [E2E test][e2e-test] GitHub action to run some
+models and validate the results.
+
+[e2e-test]: /.github/workflows/e2e_test.yml

--- a/e2e_testing/check_logs.py
+++ b/e2e_testing/check_logs.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+
+def check_logs(file_path):
+  try:
+    with open(file_path) as f:
+      log_data = f.read()
+  except Exception as e:
+    print(f"Error reading log file {file_path}: {e}")
+    return 1
+
+  # Validate that the log contains the expected patterns.
+  if not re.search(r"Finished training run", log_data):
+    print("Error: 'Finished training run' not found in logs")
+    return 1
+
+  step_duration = re.search(r"Step duration:.*s", log_data)
+  if not step_duration:
+    print("Error: 'Step duration' not found in logs")
+    return 1
+
+  print(step_duration.group())
+  print("Logs check passed.")
+  return 0
+
+
+if __name__ == "__main__":
+  if len(sys.argv) != 2:
+    print("Usage: check_logs.py <log_file>")
+    sys.exit(1)
+  sys.exit(check_logs(sys.argv[1]))

--- a/e2e_testing/check_profile.py
+++ b/e2e_testing/check_profile.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def check_profile(profile_dir):
+  try:
+    # List all .xplane.pb files recursively in the given directory.
+    result = subprocess.run(
+      ["gcloud", "storage", "ls", "-r", f"{profile_dir}/**/*.xplane.pb"],
+      capture_output=True,
+      text=True,
+      check=True,
+    )
+  except subprocess.CalledProcessError as e:
+    print(f"Error running gcloud storage ls: {e}", file=sys.stderr)
+    return 1
+
+  # Count the number of matching files.
+  files = [line for line in result.stdout.splitlines() if line.strip()]
+  count = len(files)
+  if count != 1:
+    print(
+      f"Error: Expected exactly one .xplane.pb file in {profile_dir}, found {count}.",
+      file=sys.stderr,
+    )
+    print("Files found:", result.stdout)
+    return 1
+
+  print(f"Found profile at: {files[0]}")
+  print("Profile check passed.")
+  return 0
+
+
+if __name__ == "__main__":
+  if len(sys.argv) != 2:
+    print("Usage: check_profile.py <profile_dir>")
+    sys.exit(1)
+  sys.exit(check_profile(sys.argv[1]))

--- a/e2e_testing/gen_name.py
+++ b/e2e_testing/gen_name.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+import random
+import sys
+
+
+def gen_name(name: str | None):
+  # 8 random characters from a-z and 0-9
+  random_id = "".join(random.choices("abcdefghijklmnopqrstuvwxyz0123456789", k=8))
+  name = random_id if name is None else f"{name}-{random_id}"
+  return name
+
+
+if __name__ == "__main__":
+  if len(sys.argv) > 2:
+    print("Usage: gen_name.py [name]")
+    sys.exit(1)
+  print(gen_name(sys.argv[1] if len(sys.argv) > 1 else None), flush=True, end="")

--- a/torchprime/launcher/Dockerfile
+++ b/torchprime/launcher/Dockerfile
@@ -5,7 +5,6 @@ FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.6.0_3.10_tpuv
 
 ARG USE_TRANSFORMERS=false
 # Install system dependencies
-RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get install -y curl gnupg
 
 # Add the Google Cloud SDK package repository
@@ -25,7 +24,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python
 WORKDIR /workspaces
 
 # Install torchax
-RUN git clone https://github.com/pytorch/xla.git
+RUN git clone --depth 1 https://github.com/pytorch/xla.git
 WORKDIR /workspaces/xla/torchax
 RUN pip install torch_xla[pallas] \
     -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -119,9 +119,9 @@ def use(
   )
   gcloud_config_name = f"torchprime-{project}-{zone}"
   create_and_activate_gcloud(gcloud_config_name, config)
-  assert artifact_dir.startswith(
-    "gs://"
-  ), f"{artifact_dir} must be in a GCS bucket (start with gs://)"
+  assert artifact_dir.startswith("gs://"), (
+    f"{artifact_dir} must be in a GCS bucket (start with gs://)"
+  )
 
   path = write_config(config)
   click.echo(f"Written config {path.relative_to(os.getcwd())}")
@@ -168,9 +168,9 @@ def create_and_activate_gcloud(gcloud_config_name, config: Config):
   runner.run(
     [
       "gcloud",
-      "auth",
-      "application-default",
-      "set-quota-project",
+      "config",
+      "set",
+      "billing/quota_project",
       config.project,
     ],
   )
@@ -200,9 +200,16 @@ def create_and_activate_gcloud(gcloud_config_name, config: Config):
   )
 )
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
+@click.option(
+  "--name",
+  required=False,
+  help="Name of the workload (jobset). If not specified, "
+  "defaults to one based on the date and time.",
+  default=None,
+)
 @click.option("--use-hf", is_flag=True, help="Use HuggingFace transformer")
 @interactive
-def run(args, use_hf):
+def run(args, name: str | None, use_hf: bool):
   """
   Runs the provided SPMD training command as an xpk job on a GKE cluster.
   """
@@ -218,7 +225,12 @@ def run(args, use_hf):
   docker_url = buildpush(docker_project, build_arg=build_arg)
 
   # Submit xpk workload
-  datetime_str = datetime.now().strftime("%Y%m%d-%H%M%S")
+  workload_name = name
+  if workload_name is None:
+    datetime_str = datetime.now().strftime("%Y%m%d-%H%M%S")
+    workload_name = (
+      f"{os.environ['USER']}-xpk-{config.tpu_type}-{config.num_slices}-{datetime_str}"
+    )
   command = ["python", "torchprime/launcher/thunk.py"] + list(args)
 
   # Forward a bunch of important env vars.
@@ -226,11 +238,16 @@ def run(args, use_hf):
     *forward_env("HF_TOKEN"),  # HuggingFace token
     *forward_env("XLA_IR_DEBUG"),  # torch_xla debugging flag
     *forward_env("XLA_HLO_DEBUG"),  # torch_xla debugging flag
-    *forward_env("LIBTPU_INIT_ARGS"),  # XLA flag
+    *forward_env("LIBTPU_INIT_ARGS"),  # XLA flags
   ]
 
-  # Pass artifact dir as another env var.
-  artifact_arg = ["--env", f"TORCHPRIME_ARTIFACT_DIR={config.artifact_dir}"]
+  # Pass artifact dir and jobset name as env vars.
+  artifact_arg = [
+    "--env",
+    f"TORCHPRIME_ARTIFACT_DIR={config.artifact_dir}",
+    "--env",
+    f"TORCHPRIME_JOBSET_NAME={workload_name}",
+  ]
 
   ensure_command("xpk")
   xpk_command = (
@@ -243,7 +260,7 @@ def run(args, use_hf):
       "--docker-image",
       docker_url,
       "--workload",
-      f"{os.environ['USER']}-xpk-{config.tpu_type}-{config.num_slices}-{datetime_str}",
+      workload_name,
       "--tpu-type",
       config.tpu_type,
       "--num-slices",
@@ -253,6 +270,10 @@ def run(args, use_hf):
       "--project",
       config.project,
       "--enable-debug-logs",
+      # The following lets xpk propagate user program failures as jobset exit code.
+      "--restart-on-user-code-failure",
+      "--max-restarts",
+      "0",
     ]
     + env_forwarding
     + artifact_arg

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -119,9 +119,9 @@ def use(
   )
   gcloud_config_name = f"torchprime-{project}-{zone}"
   create_and_activate_gcloud(gcloud_config_name, config)
-  assert artifact_dir.startswith("gs://"), (
-    f"{artifact_dir} must be in a GCS bucket (start with gs://)"
-  )
+  assert artifact_dir.startswith(
+    "gs://"
+  ), f"{artifact_dir} must be in a GCS bucket (start with gs://)"
 
   path = write_config(config)
   click.echo(f"Written config {path.relative_to(os.getcwd())}")

--- a/torchprime/launcher/thunk.py
+++ b/torchprime/launcher/thunk.py
@@ -29,19 +29,19 @@ for s in gcs_artifact_subdir:
 # Configure XLA graph dump path before doing anything else.
 date_string = datetime.now().strftime("%Y%m%d-%H%M")
 host_name = f"{slice_id}-{worker_id}"
-jobset_name = os.getenv("JOBSET_NAME", date_string)
-xla_dump_path = f"{mounted_artifact_dir}/{host_name}/xla_dumps/{jobset_name}/"
+jobset_name = os.getenv("TORCHPRIME_JOBSET_NAME", date_string)
+xla_dump_path = mounted_artifact_dir / jobset_name / "xla_dumps" / host_name
 os.environ["XLA_FLAGS"] = " ".join(
   [
     os.getenv("XLA_FLAGS", ""),
-    f"--xla_dump_to={xla_dump_path}",
+    f"--xla_dump_to={xla_dump_path}/",
     "--xla_dump_hlo_as_proto",
   ]
 )
 print(f"Dumping XLA compiler outputs to {xla_dump_path}", flush=True)
 
 # Determine the profile dir
-profile_dir = mounted_artifact_dir / host_name
+profile_dir = mounted_artifact_dir / jobset_name / "profile" / host_name
 print(f"Profile output directory: {profile_dir}", flush=True)
 
 # Exec into the training script.


### PR DESCRIPTION
Fixes https://github.com/AI-Hypercomputer/torchprime/issues/52

## E2E test design

The workflows in [e2e_test.yml][e2e-test] does a few things:

- Set up `gcloud` credentials from a Service Account key managed in repo secrets.
- Install `torchprime`.
- Test `tp use` and point it to an XPK cluster hosted internally.
- Test `tp run` on a few models.

After kicking off the training of some models, it starts a parallel job for each
model, and runs a few checks. This is implemented in
[reusable_e2e_check.yml][e2e-check]:

- Stream the logs.
- Check workload exit code.
- Check for specific log strings that indicate training success.
- Check that there is a profile `.pb` file.

[e2e-test]: https://github.com/AI-Hypercomputer/torchprime/pull/100/files#diff-a7287cabb55032a1b0277a08d47a1c867352ff9066be89908f0b119f5aa71463
[e2e-check]: https://github.com/AI-Hypercomputer/torchprime/pull/100/files#diff-513bc76a592edb6cbb02806ab42387181e10343720b907bc15c974177ca7ed77
