### PR TITLE
Initial Llama 3.1 405B support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,10 @@ exclude = ["torchprime.*.tests.*"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--forked"  # ensure torchax and torch_xla tests don't conflict
+
+# `--forked` ensures torchax and torch_xla tests don't conflict.
+# `--ignore local_transformers` ignores any local Hugging Face transformers checkout
+addopts = "--forked --ignore local_transformers"
 
 [tool.ruff]
 indent-width = 2

--- a/torchprime/rope/rope.py
+++ b/torchprime/rope/rope.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 import torch
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RopeScaling:
   """
   RoPE scaling parameters. The defaults are what was selected in Llama 3.1.

--- a/torchprime/torch_xla_models/configs/model/llama-3.1-405b.yaml
+++ b/torchprime/torch_xla_models/configs/model/llama-3.1-405b.yaml
@@ -1,0 +1,27 @@
+defaults:
+  - _self_
+  - scaling: llama-fsdp-tp
+
+model_class: llama.LlamaForCausalLM
+vocab_size: 128256
+hidden_size: 16384
+intermediate_size: 53248
+num_hidden_layers: 126
+num_attention_heads: 128
+num_key_value_heads: 8
+hidden_act: silu
+max_position_embeddings: 131072
+bos_token_id: 128000
+eos_token_id: 128001
+tokenizer_name: meta-llama/Meta-Llama-3.1-405B
+initializer_range: 0.02
+rms_norm_eps: 1.0e-05
+attention_dropout: false
+attention_bias: false
+flash_attention: true
+rope_theta: 500000.0
+rope_scaling:
+  factor: 8.0
+  low_freq_factor: 1.0
+  high_freq_factor: 4.0
+  original_context_len: 8192

--- a/torchprime/torch_xla_models/configs/model/scaling/llama-fsdp-tp.yaml
+++ b/torchprime/torch_xla_models/configs/model/scaling/llama-fsdp-tp.yaml
@@ -1,0 +1,27 @@
+# 2D (FSDP + TP) sharding configuration for Llama models.
+
+activation_checkpoint_layers:
+ - LlamaDecoderLayer
+
+# Refer to https://github.com/pytorch/xla/issues/6379 for backward optimization barrier info.
+optimization_barrier_layers:
+ - LlamaDecoderLayer
+
+sharding:
+  # Weights
+
+  # TODO(https://github.com/AI-Hypercomputer/torchprime/issues/114): This
+  # cannot be `[tensor, fsdp]`, or the gradients will sometimes become NaN.
+  model.embed_tokens.weight: [fsdp, tensor]
+
+  model.layers.*.self_attn.q_proj.weight: [tensor, fsdp]
+  model.layers.*.self_attn.k_proj.weight: [tensor, fsdp]
+  model.layers.*.self_attn.v_proj.weight: [tensor, fsdp]
+  model.layers.*.self_attn.o_proj.weight: [fsdp, tensor]
+  model.layers.*.mlp.gate_proj.weight: [tensor, fsdp]
+  model.layers.*.mlp.up_proj.weight: [tensor, fsdp]
+  model.layers.*.mlp.down_proj.weight: [fsdp, tensor]
+  model.layers.*.input_layernorm.weight: [fsdp]
+  model.layers.*.post_attention_layernorm.weight: [fsdp]
+  model.norm.weight: [fsdp]
+  lm_head.weight: [tensor, fsdp]

--- a/torchprime/torch_xla_models/tests/test_llama.py
+++ b/torchprime/torch_xla_models/tests/test_llama.py
@@ -1,7 +1,10 @@
 import copy
-import unittest
+from dataclasses import dataclass
 
+import pytest
 import torch
+import torch.nn as nn
+import torch.test
 import torch_xla
 from omegaconf import OmegaConf
 from transformers import AutoConfig
@@ -10,95 +13,174 @@ from transformers import LlamaForCausalLM as HfLlamaForCausalLM
 from torchprime.torch_xla_models.llama import LlamaForCausalLM
 
 
-class TestYourModule(unittest.TestCase):
-  def setUp(self):
-    super().setUp()
-    torch.manual_seed(42)
-    torch_xla.manual_seed(42)
-    self.vocab_size = 128
-    config = AutoConfig.from_pretrained(
-      "meta-llama/Meta-Llama-3-8B",
-      num_hidden_layers=1,
-      num_attention_heads=8,
-      hidden_size=8,
-      intermediate_size=16,
-      vocab_size=self.vocab_size,
+@dataclass
+class LlamaFixture:
+  vocab_size: int
+  hf_model: HfLlamaForCausalLM
+  model: LlamaForCausalLM
+
+
+def get_llama_3_8b() -> LlamaFixture:
+  torch.manual_seed(42)
+  torch_xla.manual_seed(42)
+  vocab_size = 128
+  config = AutoConfig.from_pretrained(
+    "meta-llama/Meta-Llama-3-8B",
+    num_hidden_layers=1,
+    num_attention_heads=8,
+    hidden_size=64,
+    intermediate_size=16,
+    vocab_size=vocab_size,
+  )
+  config.flash_attention = False
+  torchprime_config = OmegaConf.create(
+    {
+      "vocab_size": 128,
+      "hidden_size": 64,
+      "intermediate_size": 16,
+      "num_hidden_layers": 1,
+      "num_attention_heads": 8,
+      "num_key_value_heads": 8,
+      "hidden_act": "silu",
+      "max_position_embeddings": 8192,
+      "initializer_range": 0.02,
+      "rms_norm_eps": 1.0e-05,
+      "attention_dropout": False,
+      "attention_bias": False,
+      "flash_attention": False,
+      "rope_theta": 500000.0,
+    }
+  )
+  # Place model on CPU device first
+  with torch.device("cpu"):
+    hf_model = HfLlamaForCausalLM(config)
+    model = LlamaForCausalLM(torchprime_config)
+    model.load_state_dict(hf_model.state_dict())
+  return LlamaFixture(vocab_size, hf_model, model)
+
+
+def get_llama_3_1_405b() -> LlamaFixture:
+  torch.manual_seed(42)
+  torch_xla.manual_seed(42)
+  vocab_size = 256
+  config = AutoConfig.from_pretrained(
+    "meta-llama/Meta-Llama-3.1-405B",
+    num_hidden_layers=2,
+    num_attention_heads=8,
+    hidden_size=64,
+    intermediate_size=32,
+    vocab_size=vocab_size,
+  )
+  config.flash_attention = False
+  torchprime_config = OmegaConf.create(
+    {
+      "vocab_size": 256,
+      "hidden_size": 64,
+      "intermediate_size": 32,
+      "num_hidden_layers": 2,
+      "num_attention_heads": 8,
+      "num_key_value_heads": 8,
+      "hidden_act": "silu",
+      "max_position_embeddings": 131072,
+      "initializer_range": 0.02,
+      "rms_norm_eps": 1.0e-05,
+      "attention_dropout": False,
+      "attention_bias": False,
+      "flash_attention": False,
+      "rope_theta": 500000.0,
+      "rope_scaling": {
+        "factor": 8.0,
+        "low_freq_factor": 1.0,
+        "high_freq_factor": 4.0,
+        "original_context_len": 8192,
+      },
+    }
+  )
+  # Place model on CPU device first
+  with torch.device("cpu"):
+    hf_model = HfLlamaForCausalLM(config)
+    model = LlamaForCausalLM(torchprime_config)
+    # Assert that the `inv_freq` values are the same
+    assert isinstance(model.model.layers[0].self_attn, nn.Module)
+    assert isinstance(hf_model.model.layers[0].self_attn, nn.Module)
+    assert isinstance(model.model.layers[0].self_attn.rotary_emb, nn.Module)
+    assert isinstance(hf_model.model.layers[0].self_attn.rotary_emb, nn.Module)
+    torch.testing.assert_close(
+      model.model.layers[0].self_attn.rotary_emb.inv_freq,
+      hf_model.model.layers[0].self_attn.rotary_emb.inv_freq,
     )
-    config.flash_attention = False
-    torchprime_config = OmegaConf.create(
-      {
-        "vocab_size": 128,
-        "hidden_size": 8,
-        "intermediate_size": 16,
-        "num_hidden_layers": 1,
-        "num_attention_heads": 8,
-        "num_key_value_heads": 8,
-        "hidden_act": "silu",
-        "max_position_embeddings": 8192,
-        "initializer_range": 0.02,
-        "rms_norm_eps": 1.0e-05,
-        "attention_dropout": False,
-        "attention_bias": False,
-        "flash_attention": False,
-        "rope_theta": 500000.0,
-      }
-    )
-    # place model on CPU device first
-    with torch.device("cpu"):
-      self.hf_model = HfLlamaForCausalLM(config)
-      self.model = LlamaForCausalLM(torchprime_config)
-      self.model.load_state_dict(self.hf_model.state_dict())
+    # In this simplified model architecture, hidden_size 64 / num_attention_heads 8 = 8 head dim,
+    # and the inv_freq size is half of the head dim.
+    assert model.model.layers[0].self_attn.rotary_emb.inv_freq.shape == (4,)
+    model.load_state_dict(hf_model.state_dict())
+  return LlamaFixture(vocab_size, hf_model, model)
 
-  def test_forward_our_model_against_hf_model(self):
-    device = torch_xla.device()
-    model_xla = copy.deepcopy(self.model).to(device)
-    hf_model_xla = copy.deepcopy(self.hf_model).to(device)
-    torch_xla.sync()
-    input_sizes = [8, 128, 256]
-    for input_size in input_sizes:
-      input = torch.randint(128, ((2, input_size // 2))).to(device)
-      hf_output = hf_model_xla(
-        input, labels=input, attention_mask=torch.ones_like(input)
-      )
-      llama_xla_logits, llama_xla_loss = model_xla(
-        input, labels=input, attention_mask=torch.ones_like(input)
-      )
-      torch_xla.sync()
-      self.assertTrue(
-        torch.allclose(hf_output.logits, llama_xla_logits, atol=1e-6),
-        "logits are not equal",
-      )
-      self.assertTrue(
-        torch.allclose(hf_output.loss, llama_xla_loss, atol=1e-6),
-        "loss is not equal",
-      )
 
-  def test_forward_torch_xla_against_native(self):
-    input_size = 8
-    device = torch.device("cpu")
-    input = torch.randint(self.vocab_size, ((2, input_size // 2)))
-    llama_native_logits, llama_native_loss = self.model(
-      input, labels=input, attention_mask=torch.ones_like(input)
-    )
-
-    device = torch_xla.device()
-    input = input.to(device)
-    model_xla = copy.deepcopy(self.model).to(device)
-    torch_xla.sync()
-
+@pytest.mark.parametrize(
+  "fixture",
+  [get_llama_3_8b, get_llama_3_1_405b],
+  ids=["Llama 3.0 8B", "Llama 3.1 405B"],
+)
+def test_forward_our_model_against_hf_model(fixture):
+  fixture = fixture()
+  device = torch_xla.device()
+  model_xla = copy.deepcopy(fixture.model).to(device)
+  hf_model_xla = copy.deepcopy(fixture.hf_model).to(device)
+  torch_xla.sync()
+  input_sizes = [8, 128, 256]
+  for input_size in input_sizes:
+    input = torch.randint(fixture.vocab_size, ((2, input_size // 2))).to(device)
+    hf_output = hf_model_xla(input, labels=input, attention_mask=torch.ones_like(input))
     llama_xla_logits, llama_xla_loss = model_xla(
       input, labels=input, attention_mask=torch.ones_like(input)
     )
     torch_xla.sync()
-    self.assertTrue(
-      torch.allclose(llama_native_logits, llama_xla_logits.to("cpu"), atol=1e-2),
-      "CPU run and XLA run logits are not equal",
+    torch.testing.assert_close(
+      hf_output.logits,
+      llama_xla_logits,
+      atol=1e-6,
+      rtol=1e-9,
+      msg="logits are not equal",
     )
-    self.assertTrue(
-      torch.allclose(llama_native_loss, llama_xla_loss.to("cpu"), atol=1e-2),
-      "CPU run and XLA run loss is not equal",
+    torch.testing.assert_close(
+      hf_output.loss, llama_xla_loss, atol=1e-6, rtol=1e-9, msg="loss is not equal"
     )
 
 
-if __name__ == "__main__":
-  unittest.main()
+@pytest.mark.parametrize(
+  "fixture",
+  [get_llama_3_8b, get_llama_3_1_405b],
+  ids=["Llama 3.0 8B", "Llama 3.1 405B"],
+)
+def test_forward_torch_xla_against_native(fixture):
+  fixture = fixture()
+  input_size = 8
+  device = torch.device("cpu")
+  input = torch.randint(fixture.vocab_size, ((2, input_size // 2)))
+  llama_native_logits, llama_native_loss = fixture.model(
+    input, labels=input, attention_mask=torch.ones_like(input)
+  )
+
+  device = torch_xla.device()
+  input = input.to(device)
+  model_xla = copy.deepcopy(fixture.model).to(device)
+  torch_xla.sync()
+
+  llama_xla_logits, llama_xla_loss = model_xla(
+    input, labels=input, attention_mask=torch.ones_like(input)
+  )
+  torch_xla.sync()
+  torch.testing.assert_close(
+    llama_native_logits,
+    llama_xla_logits.to("cpu"),
+    atol=1e-2,
+    rtol=1e-6,
+    msg="CPU run and XLA run logits are not equal",
+  )
+  torch.testing.assert_close(
+    llama_native_loss,
+    llama_xla_loss.to("cpu"),
+    atol=1e-2,
+    rtol=1e-6,
+    msg="CPU run and XLA run loss is not equal",
+  )

--- a/torchprime/torch_xla_models/tests/test_topology.py
+++ b/torchprime/torch_xla_models/tests/test_topology.py
@@ -1,0 +1,36 @@
+import pytest
+
+from torchprime.torch_xla_models import topology
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_spmd():
+  import torch_xla.runtime as xr
+
+  xr.use_spmd()
+
+
+def test_basic():
+  import torch_xla.runtime as xr
+
+  # TODO(https://github.com/pytorch/xla/issues/8063): `xla_force_host_platform_device_count` doesn't
+  # work on PyTorch/XLA. We must run this on the TPU for now.
+  if xr.device_type() != "TPU":
+    pytest.skip("This test only works on TPU")
+
+  multi_slice = topology.is_multi_slice()
+  num_slices = topology.get_num_slices()
+  if multi_slice:
+    assert num_slices > 1
+  else:
+    assert num_slices == 1
+
+
+def test_is_1d_sharding():
+  assert topology.is_1d_sharding((1,))
+  assert topology.is_1d_sharding((1, 1, 1, 1))
+  assert topology.is_1d_sharding((1, 1, 2, 1))
+  assert topology.is_1d_sharding((2,))
+  assert topology.is_1d_sharding((2, 1))
+  assert not topology.is_1d_sharding((2, 2))
+  assert not topology.is_1d_sharding((1, 2, 2, 1))

--- a/torchprime/torch_xla_models/topology.py
+++ b/torchprime/torch_xla_models/topology.py
@@ -1,0 +1,44 @@
+"""
+`topology` obtains information on the accelerator topology in the current environment.
+"""
+
+from functools import lru_cache
+
+import torch_xla.runtime as xr
+
+
+@lru_cache
+def is_multi_slice() -> bool:
+  """
+  Check if we are running in multi-slice/pod environment.
+  """
+  num_slices = get_num_slices()
+  return num_slices > 1
+
+
+@lru_cache
+def get_num_slices():
+  """
+  Get the number of slices (ICI connected groups of TPUs) in the environment.
+  """
+  device_attributes = xr.global_runtime_device_attributes()
+  slice_indices = []
+  for d in device_attributes:
+    index = d.get("slice_index", 0)
+    assert isinstance(
+      index, int
+    ), f"Expected slice_index to be an int, got {type(index)} {index}"
+    slice_indices.append(index)
+  num_slices = max(slice_indices) + 1
+  return num_slices
+
+
+def is_1d_sharding(mesh_values: tuple[int, ...]) -> bool:
+  """
+  Check if the devices are distributed along exactly one dimension of the virtual device mesh.
+  """
+  non_trivial = [v for v in mesh_values if v > 1]
+  if len(non_trivial) == 0:
+    # Special case if the mesh looks like `[1, 1, 1, 1]`.
+    return True
+  return len(non_trivial) == 1


### PR DESCRIPTION
Adds Llama 3.1 405B single pod support for torch_xla.

In order to train 405B on a Trillium pod, we need 64 FSDP by 4 TP
sharding. I added a `llama-fsdp-tp` scaling config that expresses the 2D
sharding configuration and we can also use that for other llama models.

This trains performantly on 1 Trillium pod. The step time was 27.395s
(see http://shortn/_fkc7ggB8PE), which is on par with the
Huggingface result (27.395s).

Longer run over 500 steps: http://shortn/_wyNRllBbOA

Tested: `tp run torchprime/torch_xla_models/train.py model=llama-3.1-405b global_batch_size=64 mesh.fsdp=64 mesh.tensor=4 dataset_config_name=wikitext-103-raw-v1 profile_step=15 profile_duration=100000 max_steps=500 logging_steps=10`