### PR TITLE
rename transformers folder to avoid naming conflit with package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ htmlcov/
 
 # Ignore local transformers repo
 **/transformers/
+**/local_transformers/
 
 # Ignore profiler outputs
 /profile/

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ version is not expected to be run.
 Torchprime supports run with huggingface models by taking advantage of `tp run`.
 To use huggingface models, you can clone
 [huggingface/transformers](https://github.com/huggingface/transformers) under
-torchprime. This allows you to pick any branch or make code modifications for
-experiment:
+torchprime and name it as `local_transformers`. This allows you to pick any
+branch or make code modifications in transformers for experiment:
 ```
-git clone https://github.com/huggingface/transformers.git
+git clone https://github.com/huggingface/transformers.git local_transformers
 ```
 If huggingface transformer doesn't exist, torchprime will automatically clone
 the repo and build the docker for experiment. To switch to huggingface models,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ addopts = "--forked"  # ensure torchax and torch_xla tests don't conflict
 [tool.ruff]
 indent-width = 2
 target-version = "py310"
+exclude = ["local_transformers"]
 
 [tool.ruff.lint]
 select = [

--- a/torchprime/hf_models/configs/default.yaml
+++ b/torchprime/hf_models/configs/default.yaml
@@ -11,7 +11,7 @@ profile_dir: "profile"
 
 # args for the hugging face run_clm.py training script
 train_script:
-  path: "transformers/examples/pytorch/language-modeling/run_clm.py"
+  path: "local_transformers/examples/pytorch/language-modeling/run_clm.py"
   args:
     dataset_name: "wikitext"
     dataset_config_name: "wikitext-103-raw-v1"
@@ -22,7 +22,7 @@ train_script:
     config_name: "torchprime/hf_models/configs/model/llama-3/config_8b.json"
     cache_dir: "cache"
     tokenizer_name: "meta-llama/Meta-Llama-3-8B"
-    block_size: 4096
+    block_size: 8192
     optim: "adafactor"
     save_strategy: "no"
     logging_strategy: "no"
@@ -32,3 +32,4 @@ train_script:
     dataloader_drop_last: true
     flash_attention: true
     max_steps: 50
+    seed: 42

--- a/torchprime/launcher/Dockerfile
+++ b/torchprime/launcher/Dockerfile
@@ -43,16 +43,16 @@ COPY . /workspaces/torchprime
 # This should not install any packages. Only symlink the source code.
 RUN pip install --no-deps -e .
 
-RUN if [ "$USE_TRANSFORMERS" = "true" ] && [ -d "transformers" ]; then \
+RUN if [ "$USE_TRANSFORMERS" = "true" ] && [ -d "local_transformers" ]; then \
         echo "Using local transformers repo"; \
     elif [ "$USE_TRANSFORMERS" = "true" ]; then \
-        echo "Cloning transformers from GitHub"; \
-        git clone --depth 1 https://github.com/huggingface/transformers.git /workspaces/torchprime/transformers; \
+        echo "Cloning transformers from GitHub and named as local_transformers"; \
+        git clone --depth 1 https://github.com/huggingface/transformers.git /workspaces/torchprime/local_transformers; \
     fi
 
 # Only install transformers if USE_TRANSFORMERS is true
 RUN if [ "$USE_TRANSFORMERS" = "true" ]; then \
-        pip install --no-deps -e /workspaces/torchprime/transformers; \
+        pip install --no-deps -e /workspaces/torchprime/local_transformers; \
         pip install --no-deps evaluate; \
     fi
 


### PR DESCRIPTION
Previously we clone transformers/ under torchprime in order to run huggingface models. This caused the issue that python files who `import transformers` will consider transformers as the one from local folder.

We renaming the `transformers` --> `local_transformers` so that it won't conflict with the package naming.