### PR TITLE
Replace nn.Linear with einsum in the model

### DIFF
--- a/torchprime/torch_xla_models/README.md
+++ b/torchprime/torch_xla_models/README.md
@@ -80,7 +80,7 @@ tp run torchprime/torch_xla_models/train.py \
 ### Llama 3.1 405B on v6e-256
 
 Recipe for global batch size 64, sequence length 8192.
-Expected step duration: 27.349s. MFU: 21.48%.
+Expected step duration: 19.642s. MFU: 29.91%.
 
 ```sh
 export LIBTPU_INIT_ARGS='--xla_tpu_enable_flash_attention=false --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_scoped_vmem_limit_kib=98304'

--- a/torchprime/torch_xla_models/configs/model/scaling/llama-fsdp-tp.yaml
+++ b/torchprime/torch_xla_models/configs/model/scaling/llama-fsdp-tp.yaml
@@ -27,7 +27,10 @@ sharding:
   lm_head.weight: [tensor, fsdp]
 
   # Activations
-  model.layers.*.self_attn: [fsdp, null, tensor]
+  model.layers.*.self_attn.q_proj: [fsdp, null, tensor]
+  model.layers.*.self_attn.k_proj: [fsdp, null, tensor]
+  model.layers.*.self_attn.v_proj: [fsdp, null, tensor]
+  model.layers.*.self_attn.o_proj: [fsdp, null, tensor]
   model.layers.*.input_layernorm: [fsdp, null, tensor]
   model.layers.*.post_attention_layernorm: [fsdp, null, tensor]
   model.layers.*.mlp: [fsdp, null, tensor]


### PR DESCRIPTION
Fixes https://github.com/AI-Hypercomputer/torchprime/issues/139.

Previously, the batch and sequence dimensions are always squished together by nn.Linear, losing some sharding annotations. This is now no longer the case.

As another proof that the sharding propagation got more sensible, I tried sharding the q/k/v proj activations explicitly:

```
  model.layers.*.self_attn.q_proj: [fsdp, null, tensor]
  model.layers.*.self_attn.k_proj: [fsdp, null, tensor]
  model.layers.*.self_attn.v_proj: [fsdp, null, tensor]
  model.layers.*.self_attn.o_proj: [fsdp, null, tensor]
```

Without replacing nn.Linear with einsum, this actually _decreases_ MFU. Now this keeps MFU unchanged in Llama 3.0 8B which is the expected behavior.

When I tested on Llama 3.1 405B on one pod, the MFU increased to 29.91% because this time it picked up the hybrid ring mesh optimization added in https://github.com/AI-Hypercomputer/torchprime/pull/117 which applies to one pod runs as well.

```
export LIBTPU_INIT_ARGS='--xla_tpu_enable_flash_attention=false --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_scoped_vmem_limit_kib=98304'

tp run torchprime/torch_xla_models/train.py model=llama-3.1-405b global_batch_size=64 ici_mesh.fsdp=64 ici_mesh.tensor=4 dataset_config_name=wikitext-103-raw-v1 profile_step=15 profile_duration=200000 max_steps=500 logging_steps=10
```

Profile: http://shortn/_uuDdu5qPrK

I also compared the loss against https://github.com/AI-Hypercomputer/torchprime/pull/108 and they converge to the same range: http://shortn/_6MuKdyAAOB