### PR TITLE
Introduce two FX graph partitioners: remat_all and remat_all_and_offload_these_inputs

### DIFF
--- a/torchprime/torch_xla_models/offloading.py
+++ b/torchprime/torch_xla_models/offloading.py
@@ -6,6 +6,7 @@ import torch.fx as fx
 from functorch.compile import aot_function, make_boxed_func  # type:ignore
 from torch.utils._pytree import tree_iter
 from torch.utils.checkpoint import CheckpointPolicy
+from torch_xla.experimental.stablehlo_custom_call import place_to_device, place_to_host
 
 from .remat_all import remat_all_partition_fn
 
@@ -56,7 +57,9 @@ def remat_all_and_offload_these_inputs(
   names_to_offload_set = set(names_to_offload)
 
   # Modify the module such that all `offload_name` tensors whose name match
-  # `names_to_offload_set` must be saved during the forward pass.
+  # `names_to_offload_set` must be saved during the forward pass. Then these
+  # nodes will show up in the output of the `fwd` graph as additional
+  # residuals. Later, we'll walk over the graph output to identify the nodes.
   for node in joint_module.graph.nodes:
     if (
       node.op == "call_function"
@@ -74,8 +77,8 @@ def remat_all_and_offload_these_inputs(
     fw_example_args = _make_arguments(fwd)
     bw_example_args = _make_arguments(bwd)
 
-  fw_name_in_output_indices = _get_name_in_output_indices(fwd)
-  bw_name_in_input_names = _get_name_in_input_names(
+  fw_name_in_output_indices = _get_offload_name_to_fw_output_indices(fwd)
+  bw_name_in_input_names = _get_offload_name_to_bw_input_names(
     bwd, num_fwd_outputs, fw_name_in_output_indices
   )
 
@@ -91,12 +94,18 @@ In the backward graph:
   """
 
   for name in names_to_offload_set:
-    assert name in fw_name_in_output_indices, _debug(
-      f"Did not find {name} in fw_name_in_output_indices: {fw_name_in_output_indices}."
-    )
-    assert name in bw_name_in_input_names, _debug(
-      f"Did not find {name} in bw_name_in_input_names: {bw_name_in_input_names}."
-    )
+    if name not in fw_name_in_output_indices:
+      raise ValueError(
+        _debug(
+          f"Did not find {name} in fw_name_in_output_indices: {fw_name_in_output_indices}."
+        )
+      )
+    if name not in bw_name_in_input_names:
+      raise ValueError(
+        _debug(
+          f"Did not find {name} in bw_name_in_input_names: {bw_name_in_input_names}."
+        )
+      )
 
   with torch.no_grad():
 
@@ -106,11 +115,7 @@ In the backward graph:
         [fw_name_in_output_indices[name] for name in names_to_offload_set]
       )
       return tuple(
-        torch.ops.xla.place_to_host(v)  # type: ignore
-        if i  # type:ignore
-        in indices_to_offload
-        else v
-        for i, v in enumerate(out)
+        place_to_host(v) if i in indices_to_offload else v for i, v in enumerate(out)
       )
 
     def backward(**kwargs):
@@ -118,9 +123,7 @@ In the backward graph:
         [bw_name_in_input_names[name] for name in names_to_offload_set]
       )
       kwargs = {
-        k: torch.ops.xla.place_to_device(v)  # type: ignore
-        if k in arguments_to_move_back
-        else v
+        k: place_to_device(v) if k in arguments_to_move_back else v
         for k, v in kwargs.items()
       }
       return bwd(**kwargs)
@@ -162,7 +165,8 @@ def _make_arguments(gm: fx.GraphModule):
   return example_args
 
 
-def _get_named_nodes(gm: torch.fx.GraphModule):
+def _get_offload_name_nodes(gm: torch.fx.GraphModule):
+  """Build a dict from `offload_name` function call nodes to their names."""
   named_nodes: dict[Any, str] = {}
 
   for node in gm.graph.nodes:
@@ -172,14 +176,18 @@ def _get_named_nodes(gm: torch.fx.GraphModule):
       and node.target.name() == offload_name._qualname  # type: ignore
     ):
       assert isinstance(node.args[1], str)
-      named_nodes[node] = node.args[1]
+      name = node.args[1]
+      named_nodes[node] = name
 
   return named_nodes
 
 
-def _get_name_in_output_indices(gm: torch.fx.GraphModule):
-  named_nodes = _get_named_nodes(gm)
-  name_in_output_indices: dict[str, int] = {}
+def _get_offload_name_to_fw_output_indices(gm: torch.fx.GraphModule):
+  """Given a forward graph `gm`, build a dict from tensor names to their
+  position in the forward graph outputs."""
+
+  named_nodes = _get_offload_name_nodes(gm)
+  res: dict[str, int] = {}
 
   for node in gm.graph.nodes:
     if node.op == "output":
@@ -188,26 +196,29 @@ def _get_name_in_output_indices(gm: torch.fx.GraphModule):
         continue
       for i, arg in enumerate(next(iter(node.args))):  # type: ignore
         if arg in named_nodes:
-          name_in_output_indices[named_nodes[arg]] = i
+          res[named_nodes[arg]] = i
 
-  return name_in_output_indices
+  return res
 
 
-def _get_name_in_input_names(
+def _get_offload_name_to_bw_input_names(
   gm: torch.fx.GraphModule,
   num_fwd_outputs: int,
-  fw_name_in_output_indices: dict[str, int],
+  offload_name_to_output_indices: dict[str, int],
 ):
-  name_in_input_names = {}
+  """Given a backward graph `gm`, build a dict from tensor names to their
+  corresponding keyword argument names in the backward graph inputs."""
+
+  res = {}
   placeholder_idx = 0
   bw_input_idx_to_name = {}
-  for k, v in fw_name_in_output_indices.items():
+  for k, v in offload_name_to_output_indices.items():
     bw_input_idx_to_name[v - num_fwd_outputs] = k
 
   for node in gm.graph.nodes:
     if node.op == "placeholder":
       if placeholder_idx in bw_input_idx_to_name:
-        name_in_input_names[bw_input_idx_to_name[placeholder_idx]] = node.target
+        res[bw_input_idx_to_name[placeholder_idx]] = node.target
       placeholder_idx += 1
 
-  return name_in_input_names
+  return res

--- a/torchprime/torch_xla_models/offloading.py
+++ b/torchprime/torch_xla_models/offloading.py
@@ -1,0 +1,213 @@
+from collections.abc import Sequence
+from typing import Any
+
+import torch
+import torch.fx as fx
+from functorch.compile import aot_function, make_boxed_func  # type:ignore
+from torch.utils._pytree import tree_iter
+from torch.utils.checkpoint import CheckpointPolicy
+
+from .remat_all import remat_all_partition_fn
+
+
+@torch.library.custom_op("xla::offload_name", mutates_args=())
+def offload_name(t: torch.Tensor, name: str) -> torch.Tensor:
+  """Given an input tensor, returns a named tensor for offloading selection.
+
+  `offload_name` is an identity function that associates the input
+  tensor with `name`. It is primarily useful in conjunction with
+  `remat_all_and_offload_these_inputs`, which will rematerialize
+  intermediate activations and also offload inputs with the specified
+  names to host memory, moving them back during the backward pass.
+  """
+  if t is None:
+    return None
+  return t.clone()
+
+
+@offload_name.register_fake
+def _offload_name_fake(t: torch.Tensor, name: str) -> torch.Tensor:
+  if t is None:
+    return None
+  return torch.empty_like(t)
+
+
+@offload_name.register_autograd
+def _offload_name_backward(ctx, grad):
+  return grad, None
+
+
+def remat_all_and_offload_these_inputs(
+  joint_module: fx.GraphModule,
+  _joint_inputs,
+  *,
+  num_fwd_outputs,
+  names_to_offload: Sequence[str],
+):
+  """Partition the graph to rematerialize forward activations and offload
+  forward inputs to host.
+
+  `remat_all_and_offload_these_inputs` will rematerialize (recompute) all
+  intermediate activations in `joint_module`, and offload inputs with the
+  specified names to host memory, moving them back during the backward pass.
+  It transforms the joint graph into separate forward and backward graphs.
+  """
+  input_device = next(iter(tree_iter(_joint_inputs))).device
+  names_to_offload_set = set(names_to_offload)
+
+  # Modify the module such that all `offload_name` tensors whose name match
+  # `names_to_offload_set` must be saved during the forward pass.
+  for node in joint_module.graph.nodes:
+    if (
+      node.op == "call_function"
+      and hasattr(node.target, "name")
+      and node.target.name() == offload_name._qualname  # type: ignore
+      and node.args[1] in names_to_offload_set
+    ):
+      # This trick is taken from https://github.com/pytorch/pytorch/blob/1eba9b3aa3c43f86f4a2c807ac8e12c4a7767340/torch/utils/checkpoint.py#L1290
+      node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+  fwd, bwd = remat_all_partition_fn(
+    joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs
+  )
+  with torch.device(input_device):
+    fw_example_args = _make_arguments(fwd)
+    bw_example_args = _make_arguments(bwd)
+
+  fw_name_in_output_indices = _get_name_in_output_indices(fwd)
+  bw_name_in_input_names = _get_name_in_input_names(
+    bwd, num_fwd_outputs, fw_name_in_output_indices
+  )
+
+  def _debug(msg):
+    return f"""
+In the forward graph:
+{fwd.print_readable()}
+
+In the backward graph:
+{bwd.print_readable()}
+
+{msg}
+  """
+
+  for name in names_to_offload_set:
+    assert name in fw_name_in_output_indices, _debug(
+      f"Did not find {name} in fw_name_in_output_indices: {fw_name_in_output_indices}."
+    )
+    assert name in bw_name_in_input_names, _debug(
+      f"Did not find {name} in bw_name_in_input_names: {bw_name_in_input_names}."
+    )
+
+  with torch.no_grad():
+
+    def forward(**kwargs):
+      out = fwd(**kwargs)
+      indices_to_offload = set(
+        [fw_name_in_output_indices[name] for name in names_to_offload_set]
+      )
+      return tuple(
+        torch.ops.xla.place_to_host(v)  # type: ignore
+        if i  # type:ignore
+        in indices_to_offload
+        else v
+        for i, v in enumerate(out)
+      )
+
+    def backward(**kwargs):
+      arguments_to_move_back = set(
+        [bw_name_in_input_names[name] for name in names_to_offload_set]
+      )
+      kwargs = {
+        k: torch.ops.xla.place_to_device(v)  # type: ignore
+        if k in arguments_to_move_back
+        else v
+        for k, v in kwargs.items()
+      }
+      return bwd(**kwargs)
+
+    # Use AOTAutograd to retrace forward and backward, thus incorporating
+    # the offloading ops.
+    graph = [None]
+
+    def get_graph(g, _):
+      graph[0] = g
+      return make_boxed_func(g)
+
+    _ = aot_function(forward, fw_compiler=get_graph)(**fw_example_args)
+    aot_forward = graph[0]
+
+    _ = aot_function(backward, fw_compiler=get_graph)(**bw_example_args)
+    aot_backward = graph[0]
+
+    return aot_forward, aot_backward
+
+
+def _make_arguments(gm: fx.GraphModule):
+  """
+  Given a graph module, `make_arguments` returns a dictionary of example inputs
+  that can be used as keyword arguments to call the graph module.
+  """
+  example_args = {}
+  for node in gm.graph.nodes:
+    if node.op != "placeholder":
+      continue
+    if "tensor_meta" in node.meta:
+      tensor_meta = node.meta["tensor_meta"]
+      tensor = torch.zeros(
+        tensor_meta.shape,
+        dtype=tensor_meta.dtype,
+        requires_grad=tensor_meta.requires_grad,
+      )
+      example_args[node.name] = tensor
+  return example_args
+
+
+def _get_named_nodes(gm: torch.fx.GraphModule):
+  named_nodes: dict[Any, str] = {}
+
+  for node in gm.graph.nodes:
+    if (
+      node.op == "call_function"
+      and hasattr(node.target, "name")
+      and node.target.name() == offload_name._qualname  # type: ignore
+    ):
+      assert isinstance(node.args[1], str)
+      named_nodes[node] = node.args[1]
+
+  return named_nodes
+
+
+def _get_name_in_output_indices(gm: torch.fx.GraphModule):
+  named_nodes = _get_named_nodes(gm)
+  name_in_output_indices: dict[str, int] = {}
+
+  for node in gm.graph.nodes:
+    if node.op == "output":
+      assert len(node.args) <= 1
+      if len(node.args) == 0:
+        continue
+      for i, arg in enumerate(next(iter(node.args))):  # type: ignore
+        if arg in named_nodes:
+          name_in_output_indices[named_nodes[arg]] = i
+
+  return name_in_output_indices
+
+
+def _get_name_in_input_names(
+  gm: torch.fx.GraphModule,
+  num_fwd_outputs: int,
+  fw_name_in_output_indices: dict[str, int],
+):
+  name_in_input_names = {}
+  placeholder_idx = 0
+  bw_input_idx_to_name = {}
+  for k, v in fw_name_in_output_indices.items():
+    bw_input_idx_to_name[v - num_fwd_outputs] = k
+
+  for node in gm.graph.nodes:
+    if node.op == "placeholder":
+      if placeholder_idx in bw_input_idx_to_name:
+        name_in_input_names[bw_input_idx_to_name[placeholder_idx]] = node.target
+      placeholder_idx += 1
+
+  return name_in_input_names

--- a/torchprime/torch_xla_models/offloading.py
+++ b/torchprime/torch_xla_models/offloading.py
@@ -62,11 +62,8 @@ def remat_all_and_offload_these_inputs(
   # residuals. Later, we'll walk over the graph output to identify the nodes.
   for node in joint_module.graph.nodes:
     if (
-      node.op == "call_function"
-      and hasattr(node.target, "name")
-      and node.target.name() == offload_name._qualname  # type: ignore
-      and node.args[1] in names_to_offload_set
-    ):
+      tensor_name := _get_tensor_name_if_node_is_offload_name(node)
+    ) and tensor_name in names_to_offload_set:
       # This trick is taken from https://github.com/pytorch/pytorch/blob/1eba9b3aa3c43f86f4a2c807ac8e12c4a7767340/torch/utils/checkpoint.py#L1290
       node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
 
@@ -170,14 +167,8 @@ def _get_offload_name_nodes(gm: torch.fx.GraphModule):
   named_nodes: dict[Any, str] = {}
 
   for node in gm.graph.nodes:
-    if (
-      node.op == "call_function"
-      and hasattr(node.target, "name")
-      and node.target.name() == offload_name._qualname  # type: ignore
-    ):
-      assert isinstance(node.args[1], str)
-      name = node.args[1]
-      named_nodes[node] = name
+    if tensor_name := _get_tensor_name_if_node_is_offload_name(node):
+      named_nodes[node] = tensor_name
 
   return named_nodes
 
@@ -222,3 +213,18 @@ def _get_offload_name_to_bw_input_names(
       placeholder_idx += 1
 
   return res
+
+
+def _get_tensor_name_if_node_is_offload_name(node: torch.fx.Node) -> str | None:
+  """If the node is a call to the `offload_name` function, return the `name` string argument
+  that was used to call the function. Otherwise, return None.
+  """
+  if (
+    node.op == "call_function"
+    and hasattr(node.target, "name")
+    and node.target.name() == offload_name._qualname  # type: ignore
+  ):
+    assert isinstance(node.args[1], str)
+    return node.args[1]
+
+  return None

--- a/torchprime/torch_xla_models/remat_all.py
+++ b/torchprime/torch_xla_models/remat_all.py
@@ -1,0 +1,80 @@
+from contextlib import contextmanager
+
+import torch._functorch.config
+import torch.fx
+from functorch.compile import min_cut_rematerialization_partition
+from torch.utils.checkpoint import CheckpointPolicy
+
+
+def remat_all_partition_fn(
+  joint_module: torch.fx.GraphModule,
+  _joint_inputs,
+  *,
+  num_fwd_outputs,
+):
+  """
+  remat_all_partition_fn is a graph partition function that closely matches the
+  default behavior of `torch.utils.checkpoint`, which is to discard all intermediate
+  activations and recompute all of them during the backward pass.
+  """
+  with _remat_all_config():
+    # Mark anything that does not have a policy as MUST_RECOMPUTE
+    for node in joint_module.graph.nodes:
+      if node.op == "call_function" and "recompute" not in node.meta:
+        # This trick is taken from https://github.com/pytorch/pytorch/blob/1eba9b3aa3c43f86f4a2c807ac8e12c4a7767340/torch/utils/checkpoint.py#L1290
+        node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+
+        # min_cut_rematerialization_partition checks the graph ID to handle multiple
+        # graphs at once. We only have one graph so this can simply be 0.
+        node.meta["ac_graph_id"] = 0
+
+    return min_cut_rematerialization_partition(
+      joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs
+    )
+
+
+@contextmanager
+def _remat_all_config():
+  # Backup existing config values
+  backup = {
+    "aggressive_recomputation": torch._functorch.config.aggressive_recomputation,
+    "recompute_views": torch._functorch.config.recompute_views,
+    "ban_recompute_reductions": torch._functorch.config.ban_recompute_reductions,
+    "ban_recompute_not_in_allowlist": torch._functorch.config.ban_recompute_not_in_allowlist,
+    "ban_recompute_materialized_backward": torch._functorch.config.ban_recompute_materialized_backward,
+    "ban_recompute_long_fusible_chains": torch._functorch.config.ban_recompute_long_fusible_chains,
+    "ban_recompute_used_far_apart": torch._functorch.config.ban_recompute_used_far_apart,
+  }
+
+  try:
+    # Don't ban the recomputing of any ops.
+    torch._functorch.config.aggressive_recomputation = True
+    torch._functorch.config.recompute_views = True
+    torch._functorch.config.ban_recompute_reductions = False
+    torch._functorch.config.ban_recompute_not_in_allowlist = False
+    torch._functorch.config.ban_recompute_materialized_backward = False
+    torch._functorch.config.ban_recompute_long_fusible_chains = False
+    torch._functorch.config.ban_recompute_used_far_apart = False
+    yield
+
+  finally:
+    # Restore the original config values
+    torch._functorch.config.aggressive_recomputation = backup[
+      "aggressive_recomputation"
+    ]
+    torch._functorch.config.recompute_views = backup["recompute_views"]
+    torch._functorch.config.ban_recompute_reductions = backup[
+      "ban_recompute_reductions"
+    ]
+    torch._functorch.config.ban_recompute_not_in_allowlist = backup[
+      "ban_recompute_not_in_allowlist"
+    ]
+    torch._functorch.config.ban_recompute_materialized_backward = backup[
+      "ban_recompute_materialized_backward"
+    ]
+    torch._functorch.config.ban_recompute_long_fusible_chains = backup[
+      "ban_recompute_long_fusible_chains"
+    ]
+    torch._functorch.config.ban_recompute_used_far_apart = backup[
+      "ban_recompute_used_far_apart"
+    ]

--- a/torchprime/torch_xla_models/remat_all.py
+++ b/torchprime/torch_xla_models/remat_all.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import torch._functorch.config
 import torch.fx
 from functorch.compile import min_cut_rematerialization_partition
@@ -17,64 +15,25 @@ def remat_all_partition_fn(
   default behavior of `torch.utils.checkpoint`, which is to discard all intermediate
   activations and recompute all of them during the backward pass.
   """
-  with _remat_all_config():
-    # Mark anything that does not have a policy as MUST_RECOMPUTE
-    for node in joint_module.graph.nodes:
-      if node.op == "call_function" and "recompute" not in node.meta:
-        # This trick is taken from https://github.com/pytorch/pytorch/blob/1eba9b3aa3c43f86f4a2c807ac8e12c4a7767340/torch/utils/checkpoint.py#L1290
-        node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+  # Mark anything that does not have a policy as MUST_RECOMPUTE
+  for node in joint_module.graph.nodes:
+    if _is_call(node) and "recompute" not in node.meta:
+      # This trick is taken from https://github.com/pytorch/pytorch/blob/1eba9b3aa3c43f86f4a2c807ac8e12c4a7767340/torch/utils/checkpoint.py#L1290
+      node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
 
-        # min_cut_rematerialization_partition checks the graph ID to handle multiple
-        # graphs at once. We only have one graph so this can simply be 0.
-        node.meta["ac_graph_id"] = 0
+      # min_cut_rematerialization_partition checks the graph ID to handle multiple
+      # graphs at once. We only have one graph so this can simply be 0.
+      node.meta["ac_graph_id"] = 0
 
-    return min_cut_rematerialization_partition(
-      joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs
-    )
+  return min_cut_rematerialization_partition(
+    joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs
+  )
 
 
-@contextmanager
-def _remat_all_config():
-  # Backup existing config values
-  backup = {
-    "aggressive_recomputation": torch._functorch.config.aggressive_recomputation,
-    "recompute_views": torch._functorch.config.recompute_views,
-    "ban_recompute_reductions": torch._functorch.config.ban_recompute_reductions,
-    "ban_recompute_not_in_allowlist": torch._functorch.config.ban_recompute_not_in_allowlist,
-    "ban_recompute_materialized_backward": torch._functorch.config.ban_recompute_materialized_backward,
-    "ban_recompute_long_fusible_chains": torch._functorch.config.ban_recompute_long_fusible_chains,
-    "ban_recompute_used_far_apart": torch._functorch.config.ban_recompute_used_far_apart,
-  }
-
-  try:
-    # Don't ban the recomputing of any ops.
-    torch._functorch.config.aggressive_recomputation = True
-    torch._functorch.config.recompute_views = True
-    torch._functorch.config.ban_recompute_reductions = False
-    torch._functorch.config.ban_recompute_not_in_allowlist = False
-    torch._functorch.config.ban_recompute_materialized_backward = False
-    torch._functorch.config.ban_recompute_long_fusible_chains = False
-    torch._functorch.config.ban_recompute_used_far_apart = False
-    yield
-
-  finally:
-    # Restore the original config values
-    torch._functorch.config.aggressive_recomputation = backup[
-      "aggressive_recomputation"
-    ]
-    torch._functorch.config.recompute_views = backup["recompute_views"]
-    torch._functorch.config.ban_recompute_reductions = backup[
-      "ban_recompute_reductions"
-    ]
-    torch._functorch.config.ban_recompute_not_in_allowlist = backup[
-      "ban_recompute_not_in_allowlist"
-    ]
-    torch._functorch.config.ban_recompute_materialized_backward = backup[
-      "ban_recompute_materialized_backward"
-    ]
-    torch._functorch.config.ban_recompute_long_fusible_chains = backup[
-      "ban_recompute_long_fusible_chains"
-    ]
-    torch._functorch.config.ban_recompute_used_far_apart = backup[
-      "ban_recompute_used_far_apart"
-    ]
+def _is_call(node: torch.fx.Node):
+  # See documentation here: https://pytorch.org/docs/stable/fx.html
+  match node.op:
+    case "call_function" | "call_method" | "call_module":
+      return True
+    case _:
+      return False

--- a/torchprime/torch_xla_models/tests/test_offloading.py
+++ b/torchprime/torch_xla_models/tests/test_offloading.py
@@ -1,0 +1,112 @@
+from functools import partial
+
+import pytest
+import torch
+import torch_xla
+from functorch.compile import aot_function  # type:ignore
+
+from torchprime.torch_xla_models.offloading import (
+  offload_name,
+  remat_all_and_offload_these_inputs,
+)
+
+from .test_remat_all import _count_function_calls, _make_get_graph_compiler
+
+
+def test_offload_simple():
+  def fn(x, y):
+    x = offload_name(x, "x")
+    a = x @ y
+    b = torch.sin(a)
+    c = torch.exp(b)
+    return c
+
+  fw_compiler, get_fwd = _make_get_graph_compiler()
+  bw_compiler, get_bwd = _make_get_graph_compiler()
+
+  x = torch.randn((1, 10)).to(torch_xla.device()).detach().requires_grad_(True)
+  y = torch.randn((10, 1)).to(torch_xla.device()).detach().requires_grad_(True)
+  fn_compiled = aot_function(
+    fn,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=partial(remat_all_and_offload_these_inputs, names_to_offload=["x"]),
+  )
+  out = fn_compiled(x, y)
+  out.backward()
+  hlo: str = torch_xla._XLAC._get_xla_tensors_hlo([x.grad])
+
+  # Test that the graph that computes `x.grad` involves two device placement ops,
+  # one to move `x` to host, another to move `x` to device.
+  assert hlo.count("annotate_device_placement") == 2
+  assert hlo.count('xla_buffer_placement="pinned_host"') == 1
+  assert hlo.count('xla_buffer_placement="device"') == 1
+
+  # Test that the forward graph contains an offloading op.
+  fw_graph = get_fwd()
+  assert _count_function_calls(fw_graph, "place_to_host") == 1
+  assert _count_function_calls(fw_graph, "place_to_device") == 0
+
+  # Test that the backward graph contains an offloading-back op.
+  bw_graph = get_bwd()
+  assert _count_function_calls(bw_graph, "place_to_host") == 0
+  assert _count_function_calls(bw_graph, "place_to_device") == 1
+
+
+def test_offload_multiple():
+  def fn(x, y):
+    x = offload_name(x, "x")
+    y = offload_name(y, "y")
+    a = x @ y
+    b = torch.sin(a)
+    c = torch.exp(b)
+    return c
+
+  fw_compiler, _ = _make_get_graph_compiler()
+  bw_compiler, _ = _make_get_graph_compiler()
+
+  x = torch.randn((1, 10)).to(torch_xla.device()).detach().requires_grad_(True)
+  y = torch.randn((10, 1)).to(torch_xla.device()).detach().requires_grad_(True)
+  fn_compiled = aot_function(
+    fn,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=partial(
+      remat_all_and_offload_these_inputs, names_to_offload=["x", "y"]
+    ),
+  )
+  out = fn_compiled(x, y)
+  out.backward()
+  hlo: str = torch_xla._XLAC._get_xla_tensors_hlo([x.grad, y.grad])
+
+  # Test that the graph involves four device placement ops, two for each grad.
+  assert hlo.count("annotate_device_placement") == 4
+  assert hlo.count('xla_buffer_placement="pinned_host"') == 2
+  assert hlo.count('xla_buffer_placement="device"') == 2
+
+
+def test_offload_wrong_name():
+  def fn(x, y):
+    x = offload_name(x, "x")
+    a = x @ y
+    b = torch.sin(a)
+    c = torch.exp(b)
+    return c
+
+  fw_compiler, _ = _make_get_graph_compiler()
+  bw_compiler, _ = _make_get_graph_compiler()
+
+  x = torch.randn((1, 10)).to(torch_xla.device()).detach().requires_grad_(True)
+  y = torch.randn((10, 1)).to(torch_xla.device()).detach().requires_grad_(True)
+
+  with pytest.raises(ValueError, match="Did not find"):
+    fn_compiled = aot_function(
+      fn,
+      fw_compiler=fw_compiler,
+      bw_compiler=bw_compiler,
+      partition_fn=partial(
+        remat_all_and_offload_these_inputs, names_to_offload=["asdfasfasdsadf"]
+      ),
+    )
+    out = fn_compiled(x, y)
+    out.backward()

--- a/torchprime/torch_xla_models/tests/test_offloading.py
+++ b/torchprime/torch_xla_models/tests/test_offloading.py
@@ -102,6 +102,54 @@ def test_offload_multiple():
   assert hlo.count('xla_buffer_placement="device"') == 2
 
 
+def test_offload_middle_tensor():
+  def fn(x, y):
+    x = torch.sin(x)
+    y = torch.sin(y)
+    x = offload_name(x, "x")
+    y = offload_name(y, "y")
+    x = torch.exp(x)
+    y = torch.exp(y)
+    return x @ y
+
+  fw_compiler, get_fwd = _make_get_graph_compiler()
+  bw_compiler, get_bwd = _make_get_graph_compiler()
+
+  x = torch.randn((1, 10)).to(torch_xla.device()).detach().requires_grad_(True)
+  y = torch.randn((10, 1)).to(torch_xla.device()).detach().requires_grad_(True)
+  fn_compiled = aot_function(
+    fn,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=partial(
+      remat_all_and_offload_these_inputs, names_to_offload=["x", "y"]
+    ),
+  )
+  out = fn_compiled(x, y)
+  out.backward()
+  hlo: str = torch_xla._XLAC._get_xla_tensors_hlo([x.grad, y.grad])
+
+  # Test that the graph involves four device placement ops, two for each grad.
+  assert hlo.count("annotate_device_placement") == 4
+  assert hlo.count('xla_buffer_placement="pinned_host"') == 2
+  assert hlo.count('xla_buffer_placement="device"') == 2
+
+  # Check the FX graph.
+  fw_graph = get_fwd()
+  bw_graph = get_bwd()
+
+  # Forward graph does two sin and two exp
+  assert _count_function_calls(fw_graph, "sin") == 2
+  assert _count_function_calls(fw_graph, "exp") == 2
+
+  # Backward graph does two cos (backward of sin) and two exp (backward of exp).
+  # It won't do two sin because the input into the exp is offloaded. Therefore,
+  # there is no need to recompute the input to the exp.
+  assert _count_function_calls(bw_graph, "sin") == 0
+  assert _count_function_calls(bw_graph, "cos") == 2
+  assert _count_function_calls(bw_graph, "exp") == 2
+
+
 def test_offload_wrong_name():
   def fn(x, y):
     x = offload_name(x, "x")

--- a/torchprime/torch_xla_models/tests/test_offloading.py
+++ b/torchprime/torch_xla_models/tests/test_offloading.py
@@ -38,6 +38,23 @@ def test_offload_simple():
 
   # Test that the graph that computes `x.grad` involves two device placement ops,
   # one to move `x` to host, another to move `x` to device.
+  #
+  # For reference, an "offload to host" HLO call looks like this:
+  #
+  #   %custom-call.4 = f32[1,10] custom-call(f32[1,10]{1,0} %p1.3),
+  #       custom_call_target="annotate_device_placement",
+  #       custom_call_has_side_effect=true,
+  #       api_version=API_VERSION_UNSPECIFIED,
+  #       frontend_attributes={_xla_buffer_placement="pinned_host"}
+  #
+  # And an "move back to device" HLO call looks like this:
+  #
+  #   %custom-call.5 = f32[1,10] custom-call(f32[1,10] %custom-call.4),
+  #       custom_call_target="annotate_device_placement",
+  #       custom_call_has_side_effect=true,
+  #       api_version=API_VERSION_UNSPECIFIED,
+  #       frontend_attributes={_xla_buffer_placement="device"}
+  #
   assert hlo.count("annotate_device_placement") == 2
   assert hlo.count('xla_buffer_placement="pinned_host"') == 1
   assert hlo.count('xla_buffer_placement="device"') == 1

--- a/torchprime/torch_xla_models/tests/test_remat_all.py
+++ b/torchprime/torch_xla_models/tests/test_remat_all.py
@@ -1,0 +1,132 @@
+import torch
+from functorch.compile import aot_function, aot_module, make_boxed_func  # type:ignore
+
+from torchprime.torch_xla_models.remat_all import remat_all_partition_fn
+
+
+def test_remat_all():
+  """Test that remat_all_partition_fn reruns all the forward operations during the backward."""
+
+  def fn(x, y):
+    a = x @ y
+    b = torch.sin(a)
+    c = torch.exp(b)
+    return c
+
+  fw_compiler, get_fwd = _make_get_graph_compiler()
+  bw_compiler, get_bwd = _make_get_graph_compiler()
+
+  x = torch.randn((1, 10), requires_grad=True)
+  y = torch.randn((10, 1), requires_grad=True)
+  fn_compiled = aot_function(
+    fn,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=remat_all_partition_fn,
+  )
+  out = fn_compiled(x, y)
+  out.backward()
+
+  fw_graph = get_fwd()
+  bw_graph = get_bwd()
+
+  # Forward graph does these ops
+  assert _count_function_calls(fw_graph, "mm") == 1
+  assert _count_function_calls(fw_graph, "sin") == 1
+  assert _count_function_calls(fw_graph, "exp") == 1
+
+  # Backward graph does these ops
+  assert _count_function_calls(bw_graph, "mm") == 3  # 1 forward + 2 backward
+  assert _count_function_calls(bw_graph, "sin") == 1  # 1 forward
+  assert _count_function_calls(bw_graph, "exp") == 1  # 1 backward (gradient of exp)
+  assert _count_function_calls(bw_graph, "cos") == 1  # 1 backward (gradient of sin)
+
+  # Test that forward outputs 2 residuals that is the two inputs. In other word,
+  # nothing else is saved.
+  c, residual_1, residual_2 = fw_graph(x, y)
+  torch.testing.assert_close(residual_1, x)
+  torch.testing.assert_close(residual_2, y)
+
+  # We can plug these into the backward to compute the gradients functionally.
+  c_grad = torch.tensor(1.0)
+  x_grad, y_grad = bw_graph(residual_1, residual_2, c_grad)
+  torch.testing.assert_close(x_grad, x.grad)
+  torch.testing.assert_close(y_grad, y.grad)
+
+
+def test_remat_all_llama3():
+  """Stress test that we can remat the decoder layer of a Llama 3 model."""
+  from .test_llama import get_llama_3_8b
+
+  fixture = get_llama_3_8b()
+  decoder_layer = fixture.model.model.layers[0]
+  input_size = 32
+  in_embedding = torch.randn((2, input_size // 2, fixture.model.config.hidden_size))
+  position_ids = torch.arange(in_embedding.shape[1]).unsqueeze(0)
+
+  fw_compiler, get_fwd = _make_get_graph_compiler()
+  bw_compiler, get_bwd = _make_get_graph_compiler()
+
+  decoder_layer_compiled = aot_module(
+    decoder_layer,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=remat_all_partition_fn,
+  )
+  out_embedding = decoder_layer_compiled(
+    in_embedding,
+    position_ids=position_ids,
+  )
+  out_embedding.sum().backward()
+
+  fw_graph = get_fwd()
+  bw_graph = get_bwd()
+
+  num_params_buffers = len(list(decoder_layer.parameters())) + len(
+    list(decoder_layer.buffers())
+  )
+  compiled_out_embedding, *residuals = fw_graph(
+    *[
+      *decoder_layer.parameters(),
+      *decoder_layer.buffers(),
+    ],
+    in_embedding,
+    position_ids,
+  )
+  torch.testing.assert_close(out_embedding, compiled_out_embedding)
+
+  # Verify that there are no intermediate activations in the residuals. In other words,
+  # the residuals consist of weights/buffers plus the two inputs (in_embedding, position_ids).
+  assert len(residuals) == num_params_buffers + 2
+
+  # We can also run the backward graph.
+  _ = bw_graph(*residuals, torch.ones_like(out_embedding))
+
+
+def _make_get_graph_compiler():
+  """Creates a compiler that records the graph, and a getter function to retrieve them."""
+  graph: list[torch.fx.GraphModule | None] = [None]
+
+  def forward_comp(fx_module: torch.fx.GraphModule, _):
+    assert graph[0] is None
+    graph[0] = fx_module
+    return make_boxed_func(fx_module)
+
+  def get_graph():
+    g = graph[0]
+    assert g is not None
+    return g
+
+  return forward_comp, get_graph
+
+
+def _count_function_calls(gm: torch.fx.GraphModule, pattern: str) -> int:
+  count = 0
+  for node in gm.graph.nodes:
+    if node.op == "call_function":
+      target = node.target
+      if callable(target):
+        target = target.__qualname__
+      if pattern in target:
+        count += 1
+  return count

--- a/torchprime/torch_xla_models/tests/test_remat_all.py
+++ b/torchprime/torch_xla_models/tests/test_remat_all.py
@@ -38,7 +38,10 @@ def test_remat_all():
   # Backward graph does these ops
   assert _count_function_calls(bw_graph, "mm") == 3  # 1 forward + 2 backward
   assert _count_function_calls(bw_graph, "sin") == 1  # 1 forward
-  assert _count_function_calls(bw_graph, "exp") == 1  # 1 backward (gradient of exp)
+  # 1 backward (gradient of exp). There is no forward exp because the output
+  # of the last node `c` in the `fn` is not required to compute gradients for nodes
+  # within the `fn`.
+  assert _count_function_calls(bw_graph, "exp") == 1
   assert _count_function_calls(bw_graph, "cos") == 1  # 1 backward (gradient of sin)
 
   # Test that forward outputs 2 residuals that is the two inputs. In other word,
@@ -52,6 +55,89 @@ def test_remat_all():
   x_grad, y_grad = bw_graph(residual_1, residual_2, c_grad)
   torch.testing.assert_close(x_grad, x.grad)
   torch.testing.assert_close(y_grad, y.grad)
+
+
+def test_remat_all_view():
+  """Test rematerialization of view operations."""
+
+  def fn(x, y):
+    a = x.view(2, 5)
+    b = a.view(5, 2)
+    c = b.view(1, 10)
+
+    d = y.view(2, 5)
+    e = d.view(5, 2)
+    f = e.view(10, 1)
+
+    g = c @ f
+    h = torch.sin(g)
+    i = h.view(1)
+    j = torch.exp(i)
+    return j
+
+  fw_compiler, get_fwd = _make_get_graph_compiler()
+  bw_compiler, get_bwd = _make_get_graph_compiler()
+
+  x = torch.randn((1, 10), requires_grad=True)
+  y = torch.randn((10, 1), requires_grad=True)
+  fn_compiled = aot_function(
+    fn,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=remat_all_partition_fn,
+  )
+  out = fn_compiled(x, y)
+  out.backward()
+
+  fw_graph = get_fwd()
+  bw_graph = get_bwd()
+
+  # Seven view in total counted from `fn`.
+  assert _count_function_calls(fw_graph, "view") == 7
+
+  # All forward views should be rematerialized in the backward, plus each of their gradients.
+  assert _count_function_calls(bw_graph, "view") == 7 * 2
+
+
+def test_remat_all_reductions():
+  """Test that even reductions can be rematerialized.
+
+  What is a "reduction"? Basically going from large input to small output, c.f.
+  https://github.com/pytorch/pytorch/blob/38e81a53324146d445a81eb8f80bccebe623eb35/torch/_functorch/partitioners.py#L1101
+  """
+
+  def fn(x, y):
+    # Reduce x from 64x64 to 2x2.
+    x = x.view(2, 2, 32, 32).sum(dim=-1).mean(dim=-1)
+    x = torch.sin(x)
+    # Reduce y from 64x64 to 2x2.
+    y = y.view(2, 2, 32, 32).sum(dim=-1).mean(dim=-1)
+    y = torch.sin(y)
+    # Multiply them into a scalar.
+    return x.reshape(1, 4) @ y.reshape(4, 1)
+
+  fw_compiler, get_fwd = _make_get_graph_compiler()
+  bw_compiler, get_bwd = _make_get_graph_compiler()
+
+  x = torch.randn((64, 64), requires_grad=True)
+  y = torch.randn((64, 64), requires_grad=True)
+  fn_compiled = aot_function(
+    fn,
+    fw_compiler=fw_compiler,
+    bw_compiler=bw_compiler,
+    partition_fn=remat_all_partition_fn,
+  )
+  out = fn_compiled(x, y)
+  out.backward()
+
+  fw_graph = get_fwd()
+  bw_graph = get_bwd()
+
+  # Sum and mean are all "reductions" and they should all still be recomputed.
+  assert _count_function_calls(fw_graph, "sum") == 2
+  assert _count_function_calls(fw_graph, "mean") == 2
+  assert _count_function_calls(bw_graph, "sum") == 2
+  assert _count_function_calls(bw_graph, "mean") == 2
 
 
 def test_remat_all_llama3():


### PR DESCRIPTION
The main purpose is to be able to add activation checkpointing and host offloading of layer inputs to scan, which will be added later. Specifically, `torch_xla` scan takes a FX graph partitioner, so we can pass `remat_all` to implement full activation checkpointing, and pass `remat_all_and_offload_these_inputs` to implement "full activation checkpointing + offloading some input tensors to host".

And add unit tests that they work as intended.