### PR TITLE
Refactor attention module

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     container:
-      image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_${{ matrix.python-version }}_tpuvm_cxx11_20250313
+      image: us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_${{ matrix.python-version }}_tpuvm_20250402
     steps:
     - uses: actions/checkout@v4
     - name: Install torchax

--- a/torchprime/launcher/Dockerfile
+++ b/torchprime/launcher/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 # Use torch_xla Python 3.10 as the base image
-FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_cxx11_20250313
+FROM us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_20250402
 
 ARG USE_TRANSFORMERS=false
 ARG USE_LOCAL_WHEEL=false

--- a/torchprime/torch_xla_models/attention.py
+++ b/torchprime/torch_xla_models/attention.py
@@ -48,7 +48,11 @@ class AttentionModule(nn.Module):
       key_states = repeat_kv(key_states, num_key_value_groups)
       value_states = repeat_kv(value_states, num_key_value_groups)
 
-    bsz, q_len, num_heads, head_dim = query_states.size()
+    bsz, num_heads, q_len, head_dim = query_states.size()
+    # TODO: q, k dim unintentionally changed after the apply_rotary_pos_emb. Use
+    # v's dim temporarily to bypass shape assertion failure.
+    head_dim = value_states.shape[-1]
+    kv_seq_len = key_states.shape[-2]
 
     # Non FA path doesn't deal with 2D sharding.
     self.partition_spec = None
@@ -107,6 +111,11 @@ class AttentionModule(nn.Module):
         attn_weights = torch.matmul(
           query_states, key_states.transpose(2, 3)
         ) / math.sqrt(head_dim)
+        if attn_weights.size() != (bsz, num_heads, q_len, kv_seq_len):
+          raise ValueError(
+            f"Attention weights should be of size {(bsz, num_heads, q_len, kv_seq_len)}, but is"
+            f" {attn_weights.size()}"
+          )
         if attention_mask is not None:  # no matter the length, we just slice it
           causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
           attn_weights = attn_weights + causal_mask
@@ -119,7 +128,7 @@ class AttentionModule(nn.Module):
         )
         attn_output = torch.matmul(attn_weights, value_states)
 
-    if attn_output.size() != (bsz, q_len, num_heads, head_dim):
+    if attn_output.size() != (bsz, num_heads, q_len, head_dim):
       raise ValueError(
         f"`attn_output` should be of size {(bsz, num_heads, q_len, head_dim)}, but is"
         f" {attn_output.size()}"

--- a/torchprime/torch_xla_models/attention.py
+++ b/torchprime/torch_xla_models/attention.py
@@ -1,0 +1,125 @@
+import math
+from typing import Any
+
+import torch
+import torch_xla.debug.profiler as xp
+import torch_xla.distributed.spmd as xs
+from torch import nn
+from torch_xla.experimental.custom_kernel import FlashAttention, flash_attention
+
+from torchprime.torch_xla_models.experimental.custom_kernel import (
+  SplashAttentionConfig,
+  splash_attention,
+)
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+  """
+  This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+  num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+  """
+  batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+  if n_rep == 1:
+    return hidden_states
+  hidden_states = hidden_states[:, :, None, :, :].expand(
+    batch, num_key_value_heads, n_rep, slen, head_dim
+  )
+  return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class AttentionModule(nn.Module):
+  def __init__(self, config, kernel_config: dict[str, Any] | None = None):
+    super().__init__()
+    self.config = config
+    # Non FA path doesn't deal with 2D sharding.
+    self.partition_spec = None
+    segment_ids_partition_spec = None
+    if xs.get_global_mesh() is not None:
+      self.partition_spec = (("data", "fsdp"), "tensor", None, None)
+      segment_ids_partition_spec = (("data", "fsdp"), None)
+
+    match self.config.attention_kernel:
+      case "splash_attention":
+        self.sa_config = SplashAttentionConfig(
+          mesh=str(xs.get_global_mesh()),
+          qkv_partition_spec=self.partition_spec,
+          segment_ids_partition_spec=segment_ids_partition_spec,
+        )
+        if kernel_config is not None:
+          for key, value in kernel_config.items():
+            if hasattr(self.sa_config, key):
+              setattr(self.sa_config, key, value)
+      case "flash_attention":
+        default_block_sizes = {
+          "block_q": 2048,
+          "block_k_major": 512,
+          "block_k": 512,
+          "block_b": 2,
+          "block_q_major_dkv": 2048,
+          "block_k_major_dkv": 512,
+          "block_q_dkv": 2048,
+          "block_k_dkv": 512,
+          "block_q_dq": 2048,
+          "block_k_dq": 256,
+          "block_k_major_dq": 512,
+        }
+        if kernel_config is not None:
+          default_block_sizes.update(kernel_config)
+        FlashAttention.DEFAULT_BLOCK_SIZES = default_block_sizes
+
+  @xp.trace_me("AttentionModule")
+  def forward(
+    self,
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+  ):
+    if self.config.attention_kernel != "splash_attention":
+      key_states = repeat_kv(key_states, self.num_key_value_groups)
+      value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+    bsz, q_len, num_heads, head_dim = query_states.size()
+
+    match self.config.attention_kernel:
+      case "splash_attention":
+        # Integrated with PyTorch/XLA Pallas Splash Attention:
+        assert (
+          xs.get_global_mesh() is not None
+        ), "Global mesh is required for Splash Attention"
+        query_states /= math.sqrt(head_dim)
+        attn_output = splash_attention(
+          query_states, key_states, value_states, self.sa_config.to_json()
+        )
+      case "flash_attention":
+        # Integrated with PyTorch/XLA Pallas Flash Attention:
+        query_states /= math.sqrt(head_dim)
+        attn_output = flash_attention(
+          query_states,
+          key_states,
+          value_states,
+          causal=True,
+          partition_spec=self.partition_spec,
+        )
+      case _:
+        attn_weights = torch.matmul(
+          query_states, key_states.transpose(2, 3)
+        ) / math.sqrt(head_dim)
+        if attention_mask is not None:  # no matter the length, we just slice it
+          causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+          attn_weights = attn_weights + causal_mask
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(
+          attn_weights, dim=-1, dtype=torch.float32
+        ).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(
+          attn_weights, p=self.config.attention_dropout, training=self.training
+        )
+        attn_output = torch.matmul(attn_weights, value_states)
+
+    if attn_output.size() != (bsz, q_len, num_heads, head_dim):
+      raise ValueError(
+        f"`attn_output` should be of size {(bsz, num_heads, q_len, head_dim)}, but is"
+        f" {attn_output.size()}"
+      )
+    return attn_output

--- a/torchprime/torch_xla_models/attention.py
+++ b/torchprime/torch_xla_models/attention.py
@@ -42,8 +42,11 @@ class AttentionModule(nn.Module):
     attention_mask: torch.Tensor | None = None,
   ):
     if self.config.attention_kernel != "splash_attention":
-      key_states = repeat_kv(key_states, self.num_key_value_groups)
-      value_states = repeat_kv(value_states, self.num_key_value_groups)
+      num_key_value_groups = (
+        self.config.num_attention_heads // self.config.num_key_value_heads
+      )
+      key_states = repeat_kv(key_states, num_key_value_groups)
+      value_states = repeat_kv(value_states, num_key_value_groups)
 
     bsz, q_len, num_heads, head_dim = query_states.size()
 

--- a/torchprime/torch_xla_models/attention.py
+++ b/torchprime/torch_xla_models/attention.py
@@ -50,8 +50,11 @@ class AttentionModule(nn.Module):
 
     bsz, num_heads, q_len, head_dim = query_states.size()
     # TODO: q, k dim unintentionally changed after the apply_rotary_pos_emb. Use
-    # v's dim temporarily to bypass shape assertion failure.
+    # v's dim temporarily to bypass shape assertion failure. Remove the
+    # following line after resolving
+    # https://github.com/AI-Hypercomputer/torchprime/issues/195.
     head_dim = value_states.shape[-1]
+
     kv_seq_len = key_states.shape[-2]
 
     # Non FA path doesn't deal with 2D sharding.

--- a/torchprime/torch_xla_models/attention.py
+++ b/torchprime/torch_xla_models/attention.py
@@ -31,41 +31,7 @@ class AttentionModule(nn.Module):
   def __init__(self, config, kernel_config: dict[str, Any] | None = None):
     super().__init__()
     self.config = config
-    # Non FA path doesn't deal with 2D sharding.
-    self.partition_spec = None
-    segment_ids_partition_spec = None
-    if xs.get_global_mesh() is not None:
-      self.partition_spec = (("data", "fsdp"), "tensor", None, None)
-      segment_ids_partition_spec = (("data", "fsdp"), None)
-
-    match self.config.attention_kernel:
-      case "splash_attention":
-        self.sa_config = SplashAttentionConfig(
-          mesh=str(xs.get_global_mesh()),
-          qkv_partition_spec=self.partition_spec,
-          segment_ids_partition_spec=segment_ids_partition_spec,
-        )
-        if kernel_config is not None:
-          for key, value in kernel_config.items():
-            if hasattr(self.sa_config, key):
-              setattr(self.sa_config, key, value)
-      case "flash_attention":
-        default_block_sizes = {
-          "block_q": 2048,
-          "block_k_major": 512,
-          "block_k": 512,
-          "block_b": 2,
-          "block_q_major_dkv": 2048,
-          "block_k_major_dkv": 512,
-          "block_q_dkv": 2048,
-          "block_k_dkv": 512,
-          "block_q_dq": 2048,
-          "block_k_dq": 256,
-          "block_k_major_dq": 512,
-        }
-        if kernel_config is not None:
-          default_block_sizes.update(kernel_config)
-        FlashAttention.DEFAULT_BLOCK_SIZES = default_block_sizes
+    self.kernel_config = kernel_config
 
   @xp.trace_me("AttentionModule")
   def forward(
@@ -81,18 +47,51 @@ class AttentionModule(nn.Module):
 
     bsz, q_len, num_heads, head_dim = query_states.size()
 
+    # Non FA path doesn't deal with 2D sharding.
+    self.partition_spec = None
+    segment_ids_partition_spec = None
+    if xs.get_global_mesh() is not None:
+      self.partition_spec = (("data", "fsdp"), "tensor", None, None)
+      segment_ids_partition_spec = (("data", "fsdp"), None)
+
     match self.config.attention_kernel:
       case "splash_attention":
         # Integrated with PyTorch/XLA Pallas Splash Attention:
         assert (
           xs.get_global_mesh() is not None
         ), "Global mesh is required for Splash Attention"
+        sa_config = SplashAttentionConfig(
+          mesh=str(xs.get_global_mesh()),
+          qkv_partition_spec=self.partition_spec,
+          segment_ids_partition_spec=segment_ids_partition_spec,
+        )
+        if self.kernel_config is not None:
+          for key, value in self.kernel_config.items():
+            if hasattr(sa_config, key):
+              setattr(sa_config, key, value)
         query_states /= math.sqrt(head_dim)
         attn_output = splash_attention(
-          query_states, key_states, value_states, self.sa_config.to_json()
+          query_states, key_states, value_states, sa_config.to_json()
         )
       case "flash_attention":
         # Integrated with PyTorch/XLA Pallas Flash Attention:
+        default_block_sizes = {
+          "block_q": 2048,
+          "block_k_major": 512,
+          "block_k": 512,
+          "block_b": 2,
+          "block_q_major_dkv": 2048,
+          "block_k_major_dkv": 512,
+          "block_q_dkv": 2048,
+          "block_k_dkv": 512,
+          "block_q_dq": 2048,
+          "block_k_dq": 256,
+          "block_k_major_dq": 512,
+        }
+        if self.kernel_config is not None:
+          default_block_sizes.update(self.kernel_config)
+        FlashAttention.DEFAULT_BLOCK_SIZES = default_block_sizes
+
         query_states /= math.sqrt(head_dim)
         attn_output = flash_attention(
           query_states,

--- a/torchprime/torch_xla_models/llama/model.py
+++ b/torchprime/torch_xla_models/llama/model.py
@@ -18,11 +18,9 @@
 # limitations under the License.
 """PyTorch LLaMA model."""
 
-import math
 
 import torch
 import torch_xla.debug.profiler as xp
-import torch_xla.distributed.spmd as xs
 from omegaconf import DictConfig
 from torch import nn
 from transformers.activations import ACT2FN
@@ -31,6 +29,7 @@ from transformers.utils import logging
 from torchprime.layers.sequential import HomogeneousSequential
 from torchprime.rope.rope import RopeScaling, llama3_rope_frequencies
 from torchprime.torch_xla_models import offloading
+from torchprime.torch_xla_models.attention import AttentionModule
 from torchprime.torch_xla_models.loss import cross_entropy_loss
 
 logger = logging.get_logger(__name__)
@@ -160,6 +159,7 @@ class LlamaAttention(nn.Module):
   def __init__(self, config: DictConfig, layer_idx: int | None = None):
     super().__init__()
     self.config = config
+    self.attention_block = AttentionModule(config)
     self.layer_idx = layer_idx
     if layer_idx is None:
       logger.warning_once(
@@ -168,7 +168,6 @@ class LlamaAttention(nn.Module):
         "when creating this class."
       )
 
-    self.attention_dropout = config.attention_dropout
     self.hidden_size = config.hidden_size
     self.num_heads = config.num_attention_heads
     self.head_dim = self.hidden_size // self.num_heads
@@ -238,77 +237,12 @@ class LlamaAttention(nn.Module):
     cos, sin = self.rotary_emb(value_states, position_ids)
     query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
-    if self.config.attention_kernel != "splash_attention":
-      key_states = repeat_kv(key_states, self.num_key_value_groups)
-      value_states = repeat_kv(value_states, self.num_key_value_groups)
-
-    # Non FA path doesn't deal with 2D sharding.
-    partition_spec = None
-    if xs.get_global_mesh() is not None:
-      partition_spec = (("data", "fsdp"), "tensor", None, None)
-      segment_ids_partition_spec = (("data", "fsdp"), None)
-    if self.config.attention_kernel == "splash_attention":
-      # Integrated with PyTorch/XLA Pallas Splash Attention:
-      assert (
-        xs.get_global_mesh() is not None
-      ), "Global mesh is required for Splash Attention"
-      from torchprime.torch_xla_models.experimental.custom_kernel import (
-        SplashAttentionConfig,
-        splash_attention,
-      )
-
-      sa_config = SplashAttentionConfig(
-        mesh=str(xs.get_global_mesh()),
-        qkv_partition_spec=partition_spec,
-        segment_ids_partition_spec=segment_ids_partition_spec,
-      )
-      query_states /= math.sqrt(self.head_dim)
-      attn_output = splash_attention(
-        query_states, key_states, value_states, sa_config.to_json()
-      )
-    elif self.config.attention_kernel == "flash_attention":
-      # Integrated with PyTorch/XLA Pallas Flash Attention:
-      from torch_xla.experimental.custom_kernel import flash_attention
-
-      query_states /= math.sqrt(self.head_dim)
-
-      attn_output = flash_attention(
-        query_states,
-        key_states,
-        value_states,
-        causal=True,
-        partition_spec=partition_spec,
-      )
-    else:
-      attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(
-        self.head_dim
-      )
-
-      if attention_mask is not None:  # no matter the length, we just slice it
-        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
-        attn_weights = attn_weights + causal_mask
-
-      # upcast attention to fp32
-      attn_weights = nn.functional.softmax(
-        attn_weights, dim=-1, dtype=torch.float32
-      ).to(query_states.dtype)
-      attn_weights = nn.functional.dropout(
-        attn_weights, p=self.attention_dropout, training=self.training
-      )
-      attn_output = torch.matmul(attn_weights, value_states)
-
-    if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
-      raise ValueError(
-        f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
-        f" {attn_output.size()}"
-      )
-
+    attn_output = self.attention_block(
+      query_states, key_states, value_states, attention_mask
+    )
     attn_output = attn_output.transpose(1, 2).contiguous()
-
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
-
     attn_output = self.o_proj(attn_output)
-
     return attn_output
 
 

--- a/torchprime/torch_xla_models/llama/model.py
+++ b/torchprime/torch_xla_models/llama/model.py
@@ -18,7 +18,6 @@
 # limitations under the License.
 """PyTorch LLaMA model."""
 
-
 import torch
 import torch_xla.debug.profiler as xp
 from omegaconf import DictConfig

--- a/torchprime/torch_xla_models/mixtral/model.py
+++ b/torchprime/torch_xla_models/mixtral/model.py
@@ -33,6 +33,7 @@ from torch.nn import init
 from torch_xla.distributed.spmd.xla_sharding import MarkShardingFunction
 
 from torchprime.layers.sequential import HomogeneousSequential
+from torchprime.torch_xla_models.attention import AttentionModule
 from torchprime.torch_xla_models.loss import cross_entropy_loss
 from torchprime.torch_xla_models.topology import get_num_slices
 
@@ -158,6 +159,7 @@ class MixtralAttention(nn.Module):
   def __init__(self, config: DictConfig, layer_idx: int | None = None):
     super().__init__()
     self.config = config
+    self.attention_block = AttentionModule(config)
     self.layer_idx = layer_idx
 
     self.hidden_size = config.hidden_size
@@ -230,100 +232,9 @@ class MixtralAttention(nn.Module):
       query_states, key_states, cos, sin, position_ids
     )
 
-    if self.config.attention_kernel != "splash_attention":
-      # repeat k/v heads if n_kv_heads < n_heads
-      key_states = repeat_kv(key_states, self.num_key_value_groups)
-      value_states = repeat_kv(value_states, self.num_key_value_groups)
-
-    # Non FA path doesn't deal with 2D sharding.
-    partition_spec = None
-    if xs.get_global_mesh() is not None:
-      partition_spec = (("data", "fsdp"), "tensor", None, None)
-      # TODO(bhavya01): Check to see if the segment_ids_partition_spec is
-      # correct.
-      segment_ids_partition_spec = (("data", "fsdp"), None)
-    if self.config.attention_kernel == "splash_attention":
-      # Integrated with PyTorch/XLA Pallas Splash Attention:
-      assert (
-        xs.get_global_mesh() is not None
-      ), "Global mesh is required for Splash Attention"
-      from torchprime.torch_xla_models.experimental.custom_kernel import (
-        SplashAttentionConfig,
-        splash_attention,
-      )
-
-      sa_config = SplashAttentionConfig(
-        mesh=str(xs.get_global_mesh()),
-      )
-      sa_config = SplashAttentionConfig(
-        mesh=str(xs.get_global_mesh()),
-        qkv_partition_spec=partition_spec,
-        segment_ids_partition_spec=segment_ids_partition_spec,
-      )
-      query_states /= math.sqrt(self.head_dim)
-      attn_output = splash_attention(
-        query_states, key_states, value_states, sa_config.to_json()
-      )
-    elif self.config.attention_kernel == "flash_attention":
-      # Integrated with PyTorch/XLA Pallas Flash Attention:
-      from torch_xla.experimental.custom_kernel import FlashAttention, flash_attention
-
-      FlashAttention.DEFAULT_BLOCK_SIZES = {
-        "block_q": 2048,
-        "block_k_major": 512,
-        "block_k": 512,
-        "block_b": 2,
-        "block_q_major_dkv": 2048,
-        "block_k_major_dkv": 512,
-        "block_q_dkv": 2048,
-        "block_k_dkv": 512,
-        "block_q_dq": 2048,
-        "block_k_dq": 256,
-        "block_k_major_dq": 512,
-      }
-
-      query_states /= math.sqrt(self.head_dim)
-      attn_output = flash_attention(
-        query_states,
-        key_states,
-        value_states,
-        causal=True,
-        partition_spec=partition_spec,
-      )
-    else:
-      attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(
-        self.head_dim
-      )
-
-      if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
-        raise ValueError(
-          f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
-          f" {attn_weights.size()}"
-        )
-
-      if attention_mask is not None:
-        if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
-          raise ValueError(
-            f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
-          )
-
-        attn_weights = attn_weights + attention_mask
-
-      # upcast attention to fp32
-      attn_weights = nn.functional.softmax(
-        attn_weights, dim=-1, dtype=torch.float32
-      ).to(query_states.dtype)
-      attn_weights = nn.functional.dropout(
-        attn_weights, p=self.attention_dropout, training=self.training
-      )
-      attn_output = torch.matmul(attn_weights, value_states)
-
-    if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
-      raise ValueError(
-        f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
-        f" {attn_output.size()}"
-      )
-
+    attn_output = self.attention_block(
+      query_states, key_states, value_states, attention_mask
+    )
     attn_output = attn_output.transpose(1, 2).contiguous()
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
 

--- a/torchprime/torch_xla_models/mixtral/model.py
+++ b/torchprime/torch_xla_models/mixtral/model.py
@@ -215,7 +215,6 @@ class MixtralAttention(nn.Module):
     query_states = self.q_proj(hidden_states)
     key_states = self.k_proj(hidden_states)
     value_states = self.v_proj(hidden_states)
-
     query_states = query_states.view(
       bsz, q_len, self.num_heads, self.head_dim
     ).transpose(1, 2)

--- a/torchprime/torch_xla_models/offloading.py
+++ b/torchprime/torch_xla_models/offloading.py
@@ -44,6 +44,7 @@ def remat_all_and_offload_these_inputs(
   *,
   num_fwd_outputs,
   names_to_offload: Sequence[str],
+  static_lifetime_input_indices=None,
 ):
   """Partition the graph to rematerialize forward activations and offload
   forward inputs to host.
@@ -68,7 +69,10 @@ def remat_all_and_offload_these_inputs(
       node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
 
   fwd, bwd = remat_all_partition_fn(
-    joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs
+    joint_module,
+    _joint_inputs,
+    num_fwd_outputs=num_fwd_outputs,
+    static_lifetime_input_indices=static_lifetime_input_indices,
   )
   with torch.device(input_device):
     fw_example_args = _make_arguments(fwd)

--- a/torchprime/torch_xla_models/remat_all.py
+++ b/torchprime/torch_xla_models/remat_all.py
@@ -9,6 +9,7 @@ def remat_all_partition_fn(
   _joint_inputs,
   *,
   num_fwd_outputs,
+  static_lifetime_input_indices=None,
 ):
   """
   remat_all_partition_fn is a graph partition function that closely matches the
@@ -26,7 +27,10 @@ def remat_all_partition_fn(
       node.meta["ac_graph_id"] = 0
 
   return min_cut_rematerialization_partition(
-    joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs
+    joint_module,
+    _joint_inputs,
+    num_fwd_outputs=num_fwd_outputs,
+    static_lifetime_input_indices=static_lifetime_input_indices,
   )
 
 


### PR DESCRIPTION
1. Extract out the attention module into a separate file.
2. Clean up the splash attention kernel `call_jax`.

Fixes https://github.com/AI-Hypercomputer/torchprime/issues/154.