### PR TITLE
use docker-run locally without tp config

### DIFF
--- a/torchprime/launcher/Dockerfile
+++ b/torchprime/launcher/Dockerfile
@@ -24,14 +24,6 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python
 
 WORKDIR /workspaces
 
-# Install torchax
-RUN git clone --depth 1 https://github.com/pytorch/xla.git
-WORKDIR /workspaces/xla/torchax
-RUN pip install torch_xla[pallas] \
-    -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
-    -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-RUN pip install -e .
-
 # Install torchprime
 # Optimization: we rerun `pip install -e .` only if `pyproject.toml` changes.
 # Copy only the installation-related files first to make Docker cache them separately.

--- a/torchprime/launcher/buildpush.py
+++ b/torchprime/launcher/buildpush.py
@@ -5,6 +5,7 @@ import getpass
 import grp
 import os
 import random
+import re
 import string
 import subprocess
 from pathlib import Path
@@ -41,9 +42,13 @@ def buildpush(
   # Determine Docker URL
   default_url = f"gcr.io/{torchprime_project_id}/torchprime-{user}:{docker_tag}"
   docker_url = torchprime_docker_url if torchprime_docker_url else default_url
+  docker_url = re.sub(r"/+", "/", docker_url).lower()
 
   print()
-  print(f"Will build a docker image and upload to: {docker_url}")
+  if push_docker:
+    print(f"Will build a docker image and upload to: {docker_url}")
+  else:
+    print(f"Create docker image: {docker_url} and tag locally")
   print()
 
   build_cmd = f"{sudo_cmd} docker build"

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -215,15 +215,22 @@ def docker_run(args, use_hf: bool):
   """
   Runs the provided training command locally for quick testing.
   """
-  config = read_config()
+  run_with_tp_config = True
+  try:
+    config = read_config()
+  except RuntimeError:
+    run_with_tp_config = False
+    click.echo("No config found. Unable to push docker image to GCP project.")
 
   click.echo(get_project_dir().absolute())
 
   # Build docker image.
   build_arg = "USE_TRANSFORMERS=true" if use_hf else None
-  docker_project = config.docker_project
-  if docker_project is None:
-    docker_project = config.project
+  docker_project = ""
+  if run_with_tp_config:
+    docker_project = config.docker_project
+    if docker_project is None:
+      docker_project = config.project
   docker_url = buildpush(docker_project, push_docker=False, build_arg=build_arg)
   # Forward a bunch of important env vars.
   env_forwarding = [


### PR DESCRIPTION
1. Now we can run `tp docker-run` locally without `tp use` prerequisite;
2. Remove jax dependency from Dockerfile because torchax is installed with torch_xla together now. 