### PR TITLE
Bump tensorflow to 2.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ dependencies = [
     "datasets==3.0.0",
     "hydra-core==1.3.0",
     "optax==0.2.4",
-    "tensorflow-cpu==2.18.0",
-    "tensorboard==2.18.0",
-    "tensorboard-plugin-profile==2.18.0",
-    "tf_keras==2.18.0",
+    "tensorflow-cpu==2.19.0",
+    "tensorboard==2.19.0",
+    "tensorboard-plugin-profile==2.19.0",
+    "tf_keras==2.19.0",
     "protobuf==4.25.5",
 ]
 


### PR DESCRIPTION
Looks like installing 2.18 will forcefully downgrade jax to 0.53, which nullifies the recent libtpu pin update.

TEST: llama 405b 1 pod profile: http://shortn/_BlyRalgivF, logs: http://shortn/_lCU1qeMBjz