### PR TITLE
Document how to configure the sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,39 +187,7 @@ version is not expected to be run.
 
 Contributions are welcome! Please feel free to submit a pull request.
 
-Refer to the [contributor guide](./docs/contributor/README.md).
-
-### How to run inside the docker container locally
-
-You can also run locally without XPK with docker. When running inside the docker
-container, it will use the same dependencies and build process as used in the
-XPK approach, improving the hermeticity and reliability.
-
-```sh
-tp docker-run torchprime/torch_xla_models/train.py
-```
-
-This will run the torchprime docker image locally. You can also add `--use-hf`
-to run HuggingFace model locally.
-
-```sh
-tp docker-run --use-hf torchprime/hf_models/train.py
-```
-
-## Run distributed training with local torch/torch_xla wheel
-
-torchprime supports running with user specified torch and torch_xla wheels
-placed under `local_dist/` directory. The wheel will be automatically installed
-in the docker image when use `tp run` command. To use the wheel, add flag
-`--use-local-wheel` to `tp run` command:
-
-```sh
-tp run --use-local-wheel torchprime/hf_models/train.py
-```
-
-The wheels should be built inside a [PyTorch/XLA development docker
-image][torch_xla_dev_docker] or the PyTorch/XLA VSCode Dev Container to minimize
-compatibility issues.
+Refer to the [contributor guide](./docs/contributor/README.md) to get started.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -187,35 +187,7 @@ version is not expected to be run.
 
 Contributions are welcome! Please feel free to submit a pull request.
 
-When developing, use `pip install -e '.[dev]'` to install dev dependencies such
-as linter and formatter.
-
-### How to run tests
-
-```sh
-pytest
-```
-
-### How to run some of the tests, and re-run them whenever you change a file
-
-```sh
-tp -i test ... # replace with path to tests/directories
-```
-
-### How to format
-
-```sh
-ruff format
-```
-
-### How to lint
-
-```sh
-ruff check [--fix]
-```
-
-You can install a Ruff VSCode plugin to check errors and format files from the
-editor.
+Refer to the [contributor guide](./docs/contributor/README.md).
 
 ### How to run inside the docker container locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,20 @@
-# TorchPrime documentation
+# torchprime documentation
 
 This directory should contain model training guides such as how to pick
 the best sharding strategies and how to diagnose out-of-memory (OOM) errors.
+
+## User docs
+
+<!-- TODO: overall playbook for porting a model to torchprime -->
+
+[How to configure model sharding](./sharding.md)
+
+<!-- TODO: how to check model sharding once configured -->
+
+<!-- TODO(https://github.com/AI-Hypercomputer/torchprime/issues/130): OOM doc -->
+
+<!-- TODO(https://github.com/AI-Hypercomputer/torchprime/issues/124): custom mesh doc -->
+
+## Developer docs
+
+[Contributor guide](./contributor/README.md)

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -1,27 +1,27 @@
-## Contributing to torchprime
+# Contributing to torchprime
 
 When developing, use `pip install -e '.[dev]'` to install dev dependencies such
 as linter and formatter.
 
-### How to run tests
+## How to run tests
 
 ```sh
 pytest
 ```
 
-### How to run some of the tests, and re-run them whenever you change a file
+## How to run some of the tests, and re-run them whenever you change a file
 
 ```sh
 tp -i test ... # replace with path to tests/directories
 ```
 
-### How to format
+## How to format
 
 ```sh
 ruff format
 ```
 
-### How to lint
+## How to lint
 
 ```sh
 ruff check [--fix]
@@ -29,3 +29,35 @@ ruff check [--fix]
 
 You can install a Ruff VSCode plugin to check errors and format files from the
 editor.
+
+## How to run inside the docker container locally
+
+You can also run locally without XPK with docker. When running inside the docker
+container, it will use the same dependencies and build process as used in the
+XPK approach, improving the hermeticity and reliability.
+
+```sh
+tp docker-run torchprime/torch_xla_models/train.py
+```
+
+This will run the torchprime docker image locally. You can also add `--use-hf`
+to run HuggingFace model locally.
+
+```sh
+tp docker-run --use-hf torchprime/hf_models/train.py
+```
+
+## Run distributed training with local torch/torch_xla wheel
+
+torchprime supports running with user specified torch and torch_xla wheels
+placed under `local_dist/` directory. The wheel will be automatically installed
+in the docker image when use `tp run` command. To use the wheel, add flag
+`--use-local-wheel` to `tp run` command:
+
+```sh
+tp run --use-local-wheel torchprime/hf_models/train.py
+```
+
+The wheels should be built inside a [PyTorch/XLA development docker
+image][torch_xla_dev_docker] or the PyTorch/XLA VSCode Dev Container to minimize
+compatibility issues.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -1,0 +1,31 @@
+## Contributing to torchprime
+
+When developing, use `pip install -e '.[dev]'` to install dev dependencies such
+as linter and formatter.
+
+### How to run tests
+
+```sh
+pytest
+```
+
+### How to run some of the tests, and re-run them whenever you change a file
+
+```sh
+tp -i test ... # replace with path to tests/directories
+```
+
+### How to format
+
+```sh
+ruff format
+```
+
+### How to lint
+
+```sh
+ruff check [--fix]
+```
+
+You can install a Ruff VSCode plugin to check errors and format files from the
+editor.

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -34,18 +34,92 @@ https://github.com/AI-Hypercomputer/torchprime/blob/b123c0cc157c28f32a0f6588f19e
 
 ## How to shard weights
 
+To shard a particular weight in the model, simply spell out its name as it
+appears in the [state dict][state-dict], followed by the
+[partition spec][partition-spec]:
+
+```yaml
+# Shard the first dimension of the embedding layer along the `fsdp` mesh axis.
+model.embed_tokens.weight: [fsdp, null]
+```
+
+The name can also contain wildcards, which matches any integer. This is useful
+for uniformly sharding all layers in a `nn.ModuleList`:
+
+```yaml
+# Shard all query projection weights with the `[fsdp, null]` partition spec.
+model.layers.*.self_attn.q_proj.weight: [fsdp, null]
+```
+
+Internally, this is implemented as a call to
+`xs.mark_sharding(weight, mesh, partition_spec)`. See
+[`shard_torch_xla_model_from_config`][shard_torch_xla_model_from_config].
 
 ## How to shard activations
 
+Besides sharding weights, we can also shard module outputs, also called
+_activations_. To shard the output of a particular module, simply spell out its
+name as it appears in the module tree. For example, the Llama dense model class
+`LlamaForCausalLM` has two submodules: `model` and `lm_head`. The `model`
+submodule has a nested submodule called `layers`, containing the sequence of
+decoder layers. We can shard their outputs this way:
+
+```yaml
+# Shard the batch dimension of each decoder layer outputs along `fsdp` mesh axis.
+model.layers.*: [fsdp, null, null]
+
+# Shard the batch dimension of the language modeling head output along `fsdp` mesh axis.
+lm_head: [fsdp, null, null]
+```
+
+Internally, this is implemented as a call to
+`xs.mark_sharding_with_gradients(output, mesh, partition_spec)`. See
+[`shard_torch_xla_model_from_config`][shard_torch_xla_model_from_config].
+
+In FSDP (ZeRO-3), one must shard the batch dimension of all module outputs
+uniformly. However, thanks to the SPMD sharding propagation pass in the XLA
+compiler, we don't have to exhaustively list out every single module in the
+configuration file.
+
+The detailed propagation rules are spelled out in the [GSPMD][GSPMD] paper.
+A rule of thumb is that if an operation preserves an input dimension in its
+output (e.g. the batch dim in the case of batched matmul), then the sharding of
+the output dimension will inherit the sharding of the corresponding input
+dimension.
 
 ### Indexing syntax
 
+Sometimes the output of a module is a `list` or `tuple`. In order to identify
+which tensor element to shard, you could add a `[i]` suffix to the name where
+`i` is an integer that indexes into the module output. For example, we'll find
+the following configuration in the FSDP sharding config for Mixtral because the
+Mixtral decoder layer returns both the embedding and also a load balancing loss.
+
+```yaml
+# Shard the first output of the decoder layer
+model.layers.*[0]: [fsdp, null, null]
+```
+
+## Conclusion
+
+Thanks to the GSPMD feature in the PyTorch/XLA framework, we can flexibly
+implement multi-dimensional parallelism purely from configuration without
+modifying the modeling code. The examples in this guide demonstrates 1D FSDP
+but you may read on to [`llama-fsdp-tp.yaml`][llama-fsdp-tp] for combined
+FSDP + Tensor Parallelism (TP) 2D sharding. You may override the sharding from
+the command line using Hydra config syntax or create new configuration files
+as needed.
 
 <!-- xrefs -->
 
 [spmd-guide]: https://pytorch.org/xla/master/perf/spmd_basic.html
 [llama]: ../torchprime/torch_xla_models/llama/model.py
 [llama-fsdp]: ../torchprime/torch_xla_models/configs/model/sharding/llama-fsdp.yaml
+[llama-fsdp-tp]: ../torchprime/torch_xla_models/configs/model/sharding/llama-fsdp-tp.yaml
 [shard-model]: ../torchprime/sharding/shard_model.py
 [trainer]: ../torchprime/torch_xla_models/train.py
 [fsdp]: https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html
+[state-dict]: https://pytorch.org/tutorials/recipes/recipes/what_is_state_dict.html
+[partition-spec]: https://pytorch.org/xla/master/perf/spmd_basic.html#partition-spec
+[shard_torch_xla_model_from_config]: https://github.com/AI-Hypercomputer/torchprime/blob/b123c0cc157c28f32a0f6588f19e2d352d2a3617/torchprime/sharding/shard_model.py#L201
+[GSPMD]: https://arxiv.org/pdf/2105.04663

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -1,13 +1,51 @@
 # How to configure model sharding
 
-TODO: no model code change.
+Here is guide for how to shard models (i.e. apply N-dimensional parallelism)
+in torchprime.
 
-TODO: how to shard weights
+Since torchprime uses the SPMD paradigm, we recommend familiarizing with the
+[PyTorch/XLA SPMD user guide][spmd-guide] first.
 
-TODO: how to shard activations
+## Single device model + sharding configs
 
-TODO: indexing syntax
+Going from single device training to distributed training usually doesn't require
+changes to model code. For example, if we take a look at the [Llama][llama]
+model, it doesn't call any sharding/parallelism APIs in the code. This makes for
+a familiar experience for eager mode GPU users and is generally good software
+engineering practice.
 
-TODO: summarize https://chat.google.com/room/AAQA1h6amdo/sFK97OXLdYQ
+Instead, torchprime shards the model by modifying its parameters and layers
+according to configurations specified at run time. The logic is implemented in
+[`shard_model.py`][shard-model] and invoked from the [trainer][trainer]. Here is
+an example sharding configuration that implements the [FSDP (aka ZeRO-3)][fsdp]
+strategy for Llama dense models:
 
-TODO: how to check sharding? hard problem
+<!-- GitHub markdown embed -->
+https://github.com/AI-Hypercomputer/torchprime/blob/b123c0cc157c28f32a0f6588f19e2d352d2a3617/torchprime/torch_xla_models/configs/model/sharding/llama-fsdp.yaml#L1-L17
+
+
+> 📝 NOTE: Compared to the FSDP wrapper in PyTorch upstream that uses eager
+> collective operations, torchprime stages out a computation graph corresponding
+> to the training step where specific nodes in the graph are annotated with
+> sharding constraints. The XLA compiler then propagates those constraints to all
+> nodes in the graph and inserts the appropriate collective operations
+> automatically. In contrast to eager PyTorch, the XLA compiler decides the best
+> weight prefetching schedules.
+
+## How to shard weights
+
+
+## How to shard activations
+
+
+### Indexing syntax
+
+
+<!-- xrefs -->
+
+[spmd-guide]: https://pytorch.org/xla/master/perf/spmd_basic.html
+[llama]: ../torchprime/torch_xla_models/llama/model.py
+[llama-fsdp]: ../torchprime/torch_xla_models/configs/model/sharding/llama-fsdp.yaml
+[shard-model]: ../torchprime/sharding/shard_model.py
+[trainer]: ../torchprime/torch_xla_models/train.py
+[fsdp]: https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -124,5 +124,5 @@ as needed.
 [fsdp]: https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html
 [state-dict]: https://pytorch.org/tutorials/recipes/recipes/what_is_state_dict.html
 [partition-spec]: https://pytorch.org/xla/master/perf/spmd_basic.html#partition-spec
-[shard_torch_xla_model_from_config]: https://github.com/AI-Hypercomputer/torchprime/blob/b123c0cc157c28f32a0f6588f19e2d352d2a3617/torchprime/sharding/shard_model.py#L201
+[shard_torch_xla_model_from_config]: https://github.com/AI-Hypercomputer/torchprime/tree/master/torchprime/sharding/shard_model.py#L201
 [GSPMD]: https://arxiv.org/pdf/2105.04663

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -51,6 +51,9 @@ for uniformly sharding all layers in a `nn.ModuleList`:
 model.layers.*.self_attn.q_proj.weight: [fsdp, null]
 ```
 
+`null` is interpreted to be `None` in Python and means to replicate that
+tensor dimension across all devices.
+
 Internally, this is implemented as a call to
 `xs.mark_sharding(weight, mesh, partition_spec)`. See
 [`shard_torch_xla_model_from_config`][shard_torch_xla_model_from_config].

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -1,0 +1,13 @@
+# How to configure model sharding
+
+TODO: no model code change.
+
+TODO: how to shard weights
+
+TODO: how to shard activations
+
+TODO: indexing syntax
+
+TODO: summarize https://chat.google.com/room/AAQA1h6amdo/sFK97OXLdYQ
+
+TODO: how to check sharding? hard problem

--- a/torchprime/sharding/shard_model.py
+++ b/torchprime/sharding/shard_model.py
@@ -211,16 +211,11 @@ def shard_torch_xla_model_from_config(
   If `mesh` is not given, there must be a registered global mesh.
   """
   import torch_xla.distributed.spmd as xs
-  from torch_xla.distributed.spmd.xla_sharding import MarkShardingFunction
 
   def shard_activation(tensor, spec: tuple[str, ...]):
     the_mesh = mesh if mesh is not None else xs.get_global_mesh()
     assert the_mesh is not None, "No mesh found"
-    # TODO(https://github.com/pytorch/xla/issues/8678): Replace with the simpler
-    # `mark_sharding_and_gradients`.
-    out = MarkShardingFunction.apply(tensor, the_mesh, spec)
-    assert isinstance(out, torch.Tensor)
-    return out
+    return xs.mark_sharding_with_gradients(tensor, the_mesh, spec)
 
   # TODO(https://github.com/pytorch/xla/issues/8809): If we shard parameters with
   # `MarkShardingFunction.apply`, that causes Mixtral to OOM. Gradient HLO arrays end up


### PR DESCRIPTION
[See rendered markdown](https://github.com/AI-Hypercomputer/torchprime/blob/yifeit/docs-1/docs/sharding.md)

I also moved some workflows that are less likely to be used by the end-user into the contributor guide, which also lives in `docs/` now.

I also added some placeholders for other useful docs to be had.

Fixes https://github.com/AI-Hypercomputer/torchprime/issues/211.