### PR TITLE
torch_xla pin update to 0501

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -184,9 +184,9 @@ jobs:
     with:
       jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-name }}
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.04162
-      step_time_lower_bound: 2.733225455
-      step_time_upper_bound: 2.816465455
+      # Confidence interval: 0.04762
+      step_time_lower_bound: 2.73656
+      step_time_upper_bound: 2.8318
     secrets: inherit
 
   llama-3_1-8b-sa:
@@ -196,9 +196,9 @@ jobs:
     with:
       jobset_name: ${{ needs.tp-run.outputs.llama-3_1-8b-sa-name }}
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.10575
-      step_time_lower_bound: 2.345504545
-      step_time_upper_bound: 2.557004545
+      # Confidence interval: 0.10964
+      step_time_lower_bound: 2.33772
+      step_time_upper_bound: 2.557
     secrets: inherit
 
   llama-3_1-8b-scan-offload:
@@ -208,9 +208,9 @@ jobs:
     with:
       jobset_name: ${{ needs.tp-run.outputs.llama-3_1-8b-scan-offload-name }}
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.03137
-      step_time_lower_bound: 2.789257273
-      step_time_upper_bound: 2.851997273
+      # Confidence interval: 0.02826
+      step_time_lower_bound: 2.797746667
+      step_time_upper_bound: 2.854266667
     secrets: inherit
 
   llama-3-8b-2d:
@@ -220,9 +220,9 @@ jobs:
     with:
       jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-2d-name }}
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.03373
-      step_time_lower_bound: 3.33917
-      step_time_upper_bound: 3.40663
+      # Confidence interval: 0.0337
+      step_time_lower_bound: 3.336126667
+      step_time_upper_bound: 3.403526667
     secrets: inherit
 
   llama-3-8b-2-slice:
@@ -232,9 +232,9 @@ jobs:
     with:
       jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-2-slice-name }}
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 15.65875
-      step_time_lower_bound: 4.252995455
-      step_time_upper_bound: 35.57049545
+      # Confidence interval: 15.49579
+      step_time_lower_bound: 4.046396667
+      step_time_upper_bound: 35.03797667
     secrets: inherit
 
   mixtral-8x7b:
@@ -245,6 +245,6 @@ jobs:
       jobset_name: ${{ needs.tp-run.outputs.mixtral-8x7b-name }}
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
       # Confidence interval: 0.03167
-      step_time_lower_bound: 3.13563
-      step_time_upper_bound: 3.19897
+      step_time_lower_bound: 3.135123333
+      step_time_upper_bound: 3.198463333
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250426"
+torch_xla_version = "20250501"
 
 [tool.setuptools.packages.find]
 where = [""]


### PR DESCRIPTION
Bump the pinned torch_xla nightly from Apr 26 to May 1 to pick up the profiler crash fix from libtpu.

When I first created the PR (first commit), the E2E test failed because `Llama 3.0 8B` exceeds the upper bound by 3ms, while `Llama 3.0 8B 2 slice` got faster than the lower bound by 210ms. I suspect the improvement of 210ms is due to improvements in libtpu, and the exceeding of 3ms is a result of noise, since the `Llama 3.0 8B` E2E test failed on `main` before my PR as well: https://github.com/AI-Hypercomputer/torchprime/actions/runs/14613075444/job/40995666070

As a result, I took more data points including runs from this PR and updated https://docs.google.com/spreadsheets/d/1VS_0tkmmUwT22F2eeqqIOuExiBwIIbqn58MXw3RMe7M/edit?gid=0#gid=0

I then updated the confidence intervals in `e2e_test.yml` according to the calculations in the spreadsheet.