### PR TITLE
Run E2E tests with any base PyTorch/XLA docker image

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 8 * * *"  # Run daily at 12AM PST (adjusted for UTC)
+  workflow_dispatch:
 
 jobs:
   tp-run:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "0 8 * * *"  # Run daily at 12AM PST (adjusted for UTC)
   workflow_dispatch:
+    inputs:
+      docker_url:
+        description: If specified, use this PyTorch/XLA base docker image URL instead of the pin.
+        required: false
+        type: string
 
 jobs:
   tp-run:
@@ -45,6 +50,16 @@ jobs:
           tpu_type: ${{ vars.TPU_TYPE }}
           artifact_dir: ${{ env.ARTIFACT_DIR }}
           gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Setup Docker URL option
+        id: docker-url-option
+        run: |
+          if [ -n "${{ github.event.inputs.docker_url }}" ]; then
+            echo "value=--base-docker-url ${{ github.event.inputs.docker_url }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Launch training workloads.
 
       - name: Run Llama 3.0 8B
         id: run-llama-3-8b
@@ -55,7 +70,7 @@ jobs:
         run: |
           name=$(e2e_testing/gen_name.py llama-3-8b)
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          tp run \
+          tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \
             torchprime/torch_xla_models/train.py \
             model=llama-3-8b \
@@ -74,7 +89,7 @@ jobs:
         run: |
           name=$(e2e_testing/gen_name.py llama-3dot1-8b-sa)
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          tp run \
+          tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \
             torchprime/torch_xla_models/train.py \
             model=llama-3.1-8b \
@@ -94,7 +109,7 @@ jobs:
         run: |
           name=$(e2e_testing/gen_name.py llama-3dot1-8b-sa)
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          tp run \
+          tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \
             torchprime/torch_xla_models/train.py \
             model=llama-3.1-8b \
@@ -114,7 +129,7 @@ jobs:
         run: |
           name=$(e2e_testing/gen_name.py llama-3-8b-2d)
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          tp run \
+          tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \
             torchprime/torch_xla_models/train.py \
             model=llama-3-8b \
@@ -135,7 +150,7 @@ jobs:
         run: |
           name=$(e2e_testing/gen_name.py mixtral-8x7b)
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          tp run \
+          tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \
             torchprime/torch_xla_models/train.py \
             model=mixtral-8x7b \
@@ -155,7 +170,7 @@ jobs:
         run: |
           name=$(e2e_testing/gen_name.py llama-3-8b-2-slice)
           echo "name=$name" >> "$GITHUB_OUTPUT"
-          tp run \
+          tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \
             --num-slices 2 \
             torchprime/torch_xla_models/train.py \

--- a/torchprime/launcher/Dockerfile
+++ b/torchprime/launcher/Dockerfile
@@ -37,7 +37,7 @@ COPY . /workspaces/torchprime
 
 # Install torch and torch_xla from local wheels if USE_LOCAL_WHEEL and exists
 # under local_dist directory. Note that you need to build the torch and
-# torch_xla using the 
+# torch_xla using the development docker image to avoid C++ ABI incompatibilities.
 RUN if [ "$USE_LOCAL_WHEEL" = "true" ]; then \
         if [ -d "local_dist" ] && [ "$(find local_dist -name 'torch-*.whl' | wc -l)" -gt 0 ]; then \
             pip install local_dist/torch-*.whl; \


### PR DESCRIPTION
This is a supporting change to https://github.com/AI-Hypercomputer/torchprime/issues/161. In order to test torchprime from PyTorch/XLA PRs, we will build a docker image from PyTorch/XLA side and trigger the E2E check defined here.

This PR teaches torchprime to override the pinned docker image when needed during the E2E test. This way we could build new images from PyTorch/XLA side and test them.