### PR TITLE
Compute E2E bounds from BigQuery data

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -189,19 +189,20 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.load.outputs.matrix }}
-      benchmarks: ${{ steps.load.outputs.benchmarks }}
     steps:
       - uses: actions/checkout@v4
       - name: Load step_time_bounds.yaml
         id: load
         run: |
-          # Extract benchmark IDs for matrix
-          MATRIX=$(yq -o=json -I=0 '.benchmarks | keys' e2e_testing/step_time_bounds.yaml)
+          # Extract benchmarks as array of objects for matrix
+          MATRIX=$(yq -o=json -I=0 '.benchmarks | to_entries | map({
+            "benchmark": .key,
+            "name": .value.name,
+            "lower_bound": .value.step_time_lower_bound,
+            "upper_bound": .value.step_time_upper_bound
+          })' e2e_testing/step_time_bounds.yaml)
+          echo "Matrix JSON: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-
-          # Extract full benchmark data
-          BENCHMARKS=$(yq -o=json -I=0 '.benchmarks' e2e_testing/step_time_bounds.yaml)
-          echo "benchmarks=$BENCHMARKS" >> "$GITHUB_OUTPUT"
 
   # Validate the results of the workloads
   #

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -183,16 +183,16 @@ jobs:
             profile_step=3 \
             max_steps=15
 
-  # Load benchmark reference data
+  # Load reference step times
   load-benchmarks:
-    name: Load benchmark reference data
+    name: Load reference step times
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.load.outputs.matrix }}
       benchmarks: ${{ steps.load.outputs.benchmarks }}
     steps:
       - uses: actions/checkout@v4
-      - name: Load benchmark bounds
+      - name: Load step_time_bounds.yaml
         id: load
         run: |
           # Extract benchmark IDs for matrix
@@ -215,41 +215,24 @@ jobs:
   # `step_time_upper_bound - step_time_lower_bound = confidence_interval * 2`.
 
   validate:
-    name: Validate ${{ matrix.benchmark }}
+    name: ${{ matrix.config.name }}
     needs: [tp-run, load-benchmarks]
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        benchmark: ${{ fromJson(needs.load-benchmarks.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get benchmark config
-        id: config
-        run: |
-          BENCHMARKS='${{ needs.load-benchmarks.outputs.benchmarks }}'
-          BENCHMARK_DATA=$(echo "$BENCHMARKS" | jq -r '."${{ matrix.benchmark }}"')
-
-          echo "name=$(echo "$BENCHMARK_DATA" | jq -r '.name')" >> "$GITHUB_OUTPUT"
-          echo "lower_bound=$(echo "$BENCHMARK_DATA" | jq -r '.step_time_lower_bound')" >> "$GITHUB_OUTPUT"
-          echo "upper_bound=$(echo "$BENCHMARK_DATA" | jq -r '.step_time_upper_bound')" >> "$GITHUB_OUTPUT"
-
-          # Map benchmark ID to jobset name output
-          case "${{ matrix.benchmark }}" in
-            "llama-3-8b") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3-8b-name }}" ;;
-            "llama-3_1-8b-sa") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3_1-8b-sa-name }}" ;;
-            "llama-3_1-8b-scan-offload") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3_1-8b-scan-offload-name }}" ;;
-            "llama-3-8b-2d") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3-8b-2d-name }}" ;;
-            "mixtral-8x7b") JOBSET_NAME="${{ needs.tp-run.outputs.mixtral-8x7b-name }}" ;;
-            "llama-3-8b-2-slice") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3-8b-2-slice-name }}" ;;
-          esac
-
-          echo "jobset_name=$JOBSET_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Validate ${{ steps.config.outputs.name }}
-        uses: ./.github/workflows/reusable_e2e_check.yml
-        with:
-          jobset_name: ${{ steps.config.outputs.jobset_name }}
-          artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-          step_time_lower_bound: ${{ steps.config.outputs.lower_bound }}
-          step_time_upper_bound: ${{ steps.config.outputs.upper_bound }}
+        config: ${{ fromJson(needs.load-benchmarks.outputs.matrix) }}
+    uses: ./.github/workflows/reusable_e2e_check.yml
+    with:
+      jobset_name: >-
+        ${{
+          matrix.config.benchmark == 'llama-3-8b' && needs.tp-run.outputs.llama-3-8b-name ||
+          matrix.config.benchmark == 'llama-3_1-8b-sa' && needs.tp-run.outputs.llama-3_1-8b-sa-name ||
+          matrix.config.benchmark == 'llama-3_1-8b-scan-offload' && needs.tp-run.outputs.llama-3_1-8b-scan-offload-name ||
+          matrix.config.benchmark == 'llama-3-8b-2d' && needs.tp-run.outputs.llama-3-8b-2d-name ||
+          matrix.config.benchmark == 'mixtral-8x7b' && needs.tp-run.outputs.mixtral-8x7b-name ||
+          matrix.config.benchmark == 'llama-3-8b-2-slice' && needs.tp-run.outputs.llama-3-8b-2-slice-name
+        }}
+      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
+      step_time_lower_bound: ${{ matrix.config.lower_bound }}
+      step_time_upper_bound: ${{ matrix.config.upper_bound }}
+    secrets: inherit

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -194,26 +194,22 @@ jobs:
       - name: Load step_time_bounds.yaml
         id: load
         run: |
-          # Extract benchmarks as array of objects for matrix
+          # Extract benchmarks as array of objects
           MATRIX=$(yq -o=json -I=0 '.benchmarks | to_entries | map({
             "benchmark": .key,
             "name": .value.name,
             "lower_bound": .value.step_time_lower_bound,
             "upper_bound": .value.step_time_upper_bound
           })' e2e_testing/step_time_bounds.yaml)
-          echo "Matrix JSON: $MATRIX"
+          echo "Benchmark matrix JSON: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   # Validate the results of the workloads
   #
   # Each workload has a step time lower bound and upper bound.
-  #
   # The bounds and confidence intervals are programmatically derived from
   # historical E2E test results. To regenerate the bounds, you can run
   # `e2e_testing/update_step_time.py`.
-  #
-  # Note that we use the convention of
-  # `step_time_upper_bound - step_time_lower_bound = confidence_interval * 2`.
   validate:
     name: ${{ matrix.config.name }}
     needs: [tp-run, load-benchmarks]

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -107,7 +107,7 @@ jobs:
           XLA_IR_DEBUG: 1
           XLA_HLO_DEBUG: 1
         run: |
-          name=$(e2e_testing/gen_name.py llama-3dot1-8b-sa)
+          name=$(e2e_testing/gen_name.py llama-3dot1-8b-scan-offload)
           echo "name=$name" >> "$GITHUB_OUTPUT"
           tp run ${{ steps.docker-url-option.outputs.value }} \
             --name $name \

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -214,7 +214,6 @@ jobs:
   #
   # Note that we use the convention of
   # `step_time_upper_bound - step_time_lower_bound = confidence_interval * 2`.
-
   validate:
     name: ${{ matrix.config.name }}
     needs: [tp-run, load-benchmarks]

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -195,11 +195,11 @@ jobs:
       - name: Load benchmark bounds
         id: load
         run: |
-          # Extract benchmark IDs for matrix - compress to single line
+          # Extract benchmark IDs for matrix
           MATRIX=$(yq -o=json -I=0 '.benchmarks | keys' e2e_testing/step_time_bounds.yaml)
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-          # Extract full benchmark data - compress to single line
+          # Extract full benchmark data
           BENCHMARKS=$(yq -o=json -I=0 '.benchmarks' e2e_testing/step_time_bounds.yaml)
           echo "benchmarks=$BENCHMARKS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -183,84 +183,73 @@ jobs:
             profile_step=3 \
             max_steps=15
 
+  # Load benchmark reference data
+  load-benchmarks:
+    name: Load benchmark reference data
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.load.outputs.matrix }}
+      benchmarks: ${{ steps.load.outputs.benchmarks }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Load benchmark bounds
+        id: load
+        run: |
+          # Extract benchmark IDs for matrix - compress to single line
+          MATRIX=$(yq -o=json -I=0 '.benchmarks | keys' e2e_testing/step_time_bounds.yaml)
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+          # Extract full benchmark data - compress to single line
+          BENCHMARKS=$(yq -o=json -I=0 '.benchmarks' e2e_testing/step_time_bounds.yaml)
+          echo "benchmarks=$BENCHMARKS" >> "$GITHUB_OUTPUT"
+
   # Validate the results of the workloads
   #
   # Each workload has a step time lower bound and upper bound.
   #
-  # The initial bounds and confidence interval comes from a one-time analysis in Apr 2025:
-  # https://docs.google.com/spreadsheets/d/1VS_0tkmmUwT22F2eeqqIOuExiBwIIbqn58MXw3RMe7M/edit?usp=sharing
+  # The bounds and confidence intervals are programmatically derived from
+  # historical E2E test results. To regenerate the bounds, you can run
+  # `e2e_testing/update_step_time.py`.
   #
   # Note that we use the convention of
   # `step_time_upper_bound - step_time_lower_bound = confidence_interval * 2`.
 
-  llama-3-8b:
-    name: Llama 3.0 8B
-    needs: tp-run
-    uses: ./.github/workflows/reusable_e2e_check.yml
-    with:
-      jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-name }}
-      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.05506
-      step_time_lower_bound: 2.72650087
-      step_time_upper_bound: 2.83662087
-    secrets: inherit
+  validate:
+    name: Validate ${{ matrix.benchmark }}
+    needs: [tp-run, load-benchmarks]
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        benchmark: ${{ fromJson(needs.load-benchmarks.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get benchmark config
+        id: config
+        run: |
+          BENCHMARKS='${{ needs.load-benchmarks.outputs.benchmarks }}'
+          BENCHMARK_DATA=$(echo "$BENCHMARKS" | jq -r '."${{ matrix.benchmark }}"')
 
-  llama-3_1-8b-sa:
-    name: Llama 3.1 8B (Splash Attention)
-    needs: tp-run
-    uses: ./.github/workflows/reusable_e2e_check.yml
-    with:
-      jobset_name: ${{ needs.tp-run.outputs.llama-3_1-8b-sa-name }}
-      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.11286
-      step_time_lower_bound: 2.331278095
-      step_time_upper_bound: 2.556998095
-    secrets: inherit
+          echo "name=$(echo "$BENCHMARK_DATA" | jq -r '.name')" >> "$GITHUB_OUTPUT"
+          echo "lower_bound=$(echo "$BENCHMARK_DATA" | jq -r '.step_time_lower_bound')" >> "$GITHUB_OUTPUT"
+          echo "upper_bound=$(echo "$BENCHMARK_DATA" | jq -r '.step_time_upper_bound')" >> "$GITHUB_OUTPUT"
 
-  llama-3_1-8b-scan-offload:
-    name: Llama 3.1 8B (Scan + Offload)
-    needs: tp-run
-    uses: ./.github/workflows/reusable_e2e_check.yml
-    with:
-      jobset_name: ${{ needs.tp-run.outputs.llama-3_1-8b-scan-offload-name }}
-      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.0293
-      step_time_lower_bound: 2.797995238
-      step_time_upper_bound: 2.856595238
-    secrets: inherit
+          # Map benchmark ID to jobset name output
+          case "${{ matrix.benchmark }}" in
+            "llama-3-8b") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3-8b-name }}" ;;
+            "llama-3_1-8b-sa") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3_1-8b-sa-name }}" ;;
+            "llama-3_1-8b-scan-offload") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3_1-8b-scan-offload-name }}" ;;
+            "llama-3-8b-2d") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3-8b-2d-name }}" ;;
+            "mixtral-8x7b") JOBSET_NAME="${{ needs.tp-run.outputs.mixtral-8x7b-name }}" ;;
+            "llama-3-8b-2-slice") JOBSET_NAME="${{ needs.tp-run.outputs.llama-3-8b-2-slice-name }}" ;;
+          esac
 
-  llama-3-8b-2d:
-    name: Llama 3.0 8B (2D sharding)
-    needs: tp-run
-    uses: ./.github/workflows/reusable_e2e_check.yml
-    with:
-      jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-2d-name }}
-      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.0337
-      step_time_lower_bound: 3.335909524
-      step_time_upper_bound: 3.403309524
-    secrets: inherit
+          echo "jobset_name=$JOBSET_NAME" >> "$GITHUB_OUTPUT"
 
-  llama-3-8b-2-slice:
-    name: Llama 3.0 8B (2 slice)
-    needs: tp-run
-    uses: ./.github/workflows/reusable_e2e_check.yml
-    with:
-      jobset_name: ${{ needs.tp-run.outputs.llama-3-8b-2-slice-name }}
-      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.15707
-      step_time_lower_bound: 3.904201429
-      step_time_upper_bound: 4.218341429
-    secrets: inherit
-
-  mixtral-8x7b:
-    name: Mixtral 8x7B
-    needs: tp-run
-    uses: ./.github/workflows/reusable_e2e_check.yml
-    with:
-      jobset_name: ${{ needs.tp-run.outputs.mixtral-8x7b-name }}
-      artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
-      # Confidence interval: 0.03167
-      step_time_lower_bound: 3.135134762
-      step_time_upper_bound: 3.198474762
-    secrets: inherit
+      - name: Validate ${{ steps.config.outputs.name }}
+        uses: ./.github/workflows/reusable_e2e_check.yml
+        with:
+          jobset_name: ${{ steps.config.outputs.jobset_name }}
+          artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
+          step_time_lower_bound: ${{ steps.config.outputs.lower_bound }}
+          step_time_upper_bound: ${{ steps.config.outputs.upper_bound }}

--- a/e2e_testing/README.md
+++ b/e2e_testing/README.md
@@ -45,6 +45,18 @@ If there were no code changes and the step time is still above the upper bound,
 we'll need to discuss with the hardware teams because it may be the result of
 hardware changes.
 
+### Recalculating all bounds
+
+Sometimes (e.g. due to moving to different hardware or changing step time
+accounting methodology) there will be a need to recalculate all step time bounds:
+
+- First collect enough samples e.g. by manually triggering the E2E tests GitHub
+  Action a number of times.
+- Run [`update_step_time.py`](./update_step_time.py) to pull the latest E2E
+  results from the database and update the reference step time bounds file. Refer
+  to the help message of the script for how to select results from a specific
+  time span.
+
 ### Formula for computing the lower and upper bounds
 
 Let $X = \{x_1, x_2, \ldots, x_n\}$ be the observed step time for a workload.

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -1,46 +1,46 @@
 benchmarks:
   llama-3-8b:
     name: Llama 3.0 8B
-    step_time_lower_bound: 2.6772919
+    step_time_lower_bound: 2.67793406
     step_time_upper_bound: 2.788876
-    confidence_interval: 0.05579
-    average: 2.7331
-    sample_size: 145
+    confidence_interval: 0.05547
+    average: 2.7334
+    sample_size: 169
   llama-3_1-8b-sa:
     name: Llama 3.1 8B (Splash Attention)
-    step_time_lower_bound: 2.3596336
-    step_time_upper_bound: 2.452628
-    confidence_interval: 0.0465
-    average: 2.4061
-    sample_size: 145
+    step_time_lower_bound: 2.35485746
+    step_time_upper_bound: 2.457598
+    confidence_interval: 0.05137
+    average: 2.4062
+    sample_size: 169
   llama-3_1-8b-scan-offload:
     name: Llama 3.1 8B (Scan + Offload)
-    step_time_lower_bound: 2.73950752
+    step_time_lower_bound: 2.73963398
     step_time_upper_bound: 2.85849
-    confidence_interval: 0.05949
-    average: 2.799
-    sample_size: 145
+    confidence_interval: 0.05943
+    average: 2.7991
+    sample_size: 169
   llama-3-8b-2d:
     name: Llama 3.0 8B (2D sharding)
-    step_time_lower_bound: 3.28906594
-    step_time_upper_bound: 3.38924054
-    confidence_interval: 0.05009
-    average: 3.3392
-    sample_size: 145
+    step_time_lower_bound: 3.28863385
+    step_time_upper_bound: 3.38879529
+    confidence_interval: 0.05008
+    average: 3.3387
+    sample_size: 169
   mixtral-8x7b:
     name: Mixtral 8x7B
-    step_time_lower_bound: 3.09896717
-    step_time_upper_bound: 3.19335196
+    step_time_lower_bound: 3.09891705
+    step_time_upper_bound: 3.19330031
     confidence_interval: 0.04719
-    average: 3.1462
-    sample_size: 145
+    average: 3.1461
+    sample_size: 169
   llama-3-8b-2-slice:
     name: Llama 3.0 8B (2 Slice)
-    step_time_lower_bound: 3.88394539
+    step_time_lower_bound: 3.88681827
     step_time_upper_bound: 4.026164
-    confidence_interval: 0.07111
-    average: 3.9551
-    sample_size: 145
+    confidence_interval: 0.06967
+    average: 3.9565
+    sample_size: 169
 metadata:
   query_start: 2025-05-29 17:52:00 America/Los_Angeles
   query_end: 2025-06-01 20:00:00 America/Los_Angeles

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -1,0 +1,47 @@
+benchmarks:
+  llama-3-8b:
+    name: Llama 3.0 8B
+    step_time_lower_bound: 2.67770406
+    step_time_upper_bound: 2.786758
+    confidence_interval: 0.05453
+    average: 2.7322
+    sample_size: 62
+  llama-3_1-8b-sa:
+    name: Llama 3.1 8B (Splash Attention)
+    step_time_lower_bound: 2.36163758
+    step_time_upper_bound: 2.452628
+    confidence_interval: 0.0455
+    average: 2.4071
+    sample_size: 62
+  llama-3_1-8b-scan-offload:
+    name: Llama 3.1 8B (Scan + Offload)
+    step_time_lower_bound: 2.74448761
+    step_time_upper_bound: 2.857276
+    confidence_interval: 0.05639
+    average: 2.8009
+    sample_size: 62
+  llama-3-8b-2d:
+    name: Llama 3.0 8B (2D sharding)
+    step_time_lower_bound: 3.28890483
+    step_time_upper_bound: 3.38907452
+    confidence_interval: 0.05008
+    average: 3.339
+    sample_size: 62
+  mixtral-8x7b:
+    name: Mixtral 8x7B
+    step_time_lower_bound: 3.10035046
+    step_time_upper_bound: 3.19477738
+    confidence_interval: 0.04721
+    average: 3.1476
+    sample_size: 62
+  llama-3-8b-2-slice:
+    name: Llama 3.0 8B (2 Slice)
+    step_time_lower_bound: 3.87527939
+    step_time_upper_bound: 4.026164
+    confidence_interval: 0.07544
+    average: 3.9507
+    sample_size: 62
+metadata:
+  query_start: 2025-05-29 17:52:00 America/Los_Angeles
+  query_end: 2025-06-02 17:52:00 America/Los_Angeles
+  confidence_level: 0.999

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -1,46 +1,46 @@
 benchmarks:
   llama-3-8b:
     name: Llama 3.0 8B
-    step_time_lower_bound: 2.67728338
+    step_time_lower_bound: 2.67975625
     step_time_upper_bound: 2.788876
-    confidence_interval: 0.0558
-    average: 2.7331
-    sample_size: 93
+    confidence_interval: 0.05456
+    average: 2.7343
+    sample_size: 104
   llama-3_1-8b-sa:
     name: Llama 3.1 8B (Splash Attention)
-    step_time_lower_bound: 2.3585946
+    step_time_lower_bound: 2.35893329
     step_time_upper_bound: 2.452628
-    confidence_interval: 0.04702
-    average: 2.4056
-    sample_size: 93
+    confidence_interval: 0.04685
+    average: 2.4058
+    sample_size: 104
   llama-3_1-8b-scan-offload:
     name: Llama 3.1 8B (Scan + Offload)
-    step_time_lower_bound: 2.73941304
+    step_time_lower_bound: 2.73966392
     step_time_upper_bound: 2.857276
-    confidence_interval: 0.05893
-    average: 2.7983
-    sample_size: 98
+    confidence_interval: 0.05881
+    average: 2.7985
+    sample_size: 104
   llama-3-8b-2d:
     name: Llama 3.0 8B (2D sharding)
-    step_time_lower_bound: 3.28923659
-    step_time_upper_bound: 3.38941638
+    step_time_lower_bound: 3.2893677
+    step_time_upper_bound: 3.38955149
     confidence_interval: 0.05009
-    average: 3.3393
-    sample_size: 93
+    average: 3.3395
+    sample_size: 104
   mixtral-8x7b:
     name: Mixtral 8x7B
-    step_time_lower_bound: 3.09939419
-    step_time_upper_bound: 3.19379198
-    confidence_interval: 0.0472
-    average: 3.1466
-    sample_size: 94
+    step_time_lower_bound: 3.09912397
+    step_time_upper_bound: 3.19351353
+    confidence_interval: 0.04719
+    average: 3.1463
+    sample_size: 104
   llama-3-8b-2-slice:
     name: Llama 3.0 8B (2 Slice)
-    step_time_lower_bound: 3.87729011
+    step_time_lower_bound: 3.88106931
     step_time_upper_bound: 4.026164
-    confidence_interval: 0.07444
-    average: 3.9517
-    sample_size: 93
+    confidence_interval: 0.07255
+    average: 3.9536
+    sample_size: 104
 metadata:
   query_start: 2025-05-29 17:52:00 America/Los_Angeles
   query_end: 2025-06-02 17:52:00 America/Los_Angeles

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -1,46 +1,46 @@
 benchmarks:
   llama-3-8b:
     name: Llama 3.0 8B
-    step_time_lower_bound: 2.67737232
+    step_time_lower_bound: 2.67728338
     step_time_upper_bound: 2.788876
-    confidence_interval: 0.05575
+    confidence_interval: 0.0558
     average: 2.7331
-    sample_size: 88
+    sample_size: 93
   llama-3_1-8b-sa:
     name: Llama 3.1 8B (Splash Attention)
-    step_time_lower_bound: 2.3577735
+    step_time_lower_bound: 2.3585946
     step_time_upper_bound: 2.452628
-    confidence_interval: 0.04743
-    average: 2.4052
-    sample_size: 88
+    confidence_interval: 0.04702
+    average: 2.4056
+    sample_size: 93
   llama-3_1-8b-scan-offload:
     name: Llama 3.1 8B (Scan + Offload)
-    step_time_lower_bound: 2.74174618
+    step_time_lower_bound: 2.73941304
     step_time_upper_bound: 2.857276
-    confidence_interval: 0.05776
-    average: 2.7995
-    sample_size: 88
+    confidence_interval: 0.05893
+    average: 2.7983
+    sample_size: 98
   llama-3-8b-2d:
     name: Llama 3.0 8B (2D sharding)
-    step_time_lower_bound: 3.28929215
-    step_time_upper_bound: 3.38947363
+    step_time_lower_bound: 3.28923659
+    step_time_upper_bound: 3.38941638
     confidence_interval: 0.05009
-    average: 3.3394
-    sample_size: 81
+    average: 3.3393
+    sample_size: 93
   mixtral-8x7b:
     name: Mixtral 8x7B
-    step_time_lower_bound: 3.09970013
-    step_time_upper_bound: 3.19410724
+    step_time_lower_bound: 3.09939419
+    step_time_upper_bound: 3.19379198
     confidence_interval: 0.0472
-    average: 3.1469
-    sample_size: 88
+    average: 3.1466
+    sample_size: 94
   llama-3-8b-2-slice:
     name: Llama 3.0 8B (2 Slice)
-    step_time_lower_bound: 3.87682821
+    step_time_lower_bound: 3.87729011
     step_time_upper_bound: 4.026164
-    confidence_interval: 0.07467
-    average: 3.9515
-    sample_size: 75
+    confidence_interval: 0.07444
+    average: 3.9517
+    sample_size: 93
 metadata:
   query_start: 2025-05-29 17:52:00 America/Los_Angeles
   query_end: 2025-06-02 17:52:00 America/Los_Angeles

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -1,46 +1,46 @@
 benchmarks:
   llama-3-8b:
     name: Llama 3.0 8B
-    step_time_lower_bound: 2.67770406
-    step_time_upper_bound: 2.786758
-    confidence_interval: 0.05453
-    average: 2.7322
-    sample_size: 62
+    step_time_lower_bound: 2.67737232
+    step_time_upper_bound: 2.788876
+    confidence_interval: 0.05575
+    average: 2.7331
+    sample_size: 88
   llama-3_1-8b-sa:
     name: Llama 3.1 8B (Splash Attention)
-    step_time_lower_bound: 2.36163758
+    step_time_lower_bound: 2.3577735
     step_time_upper_bound: 2.452628
-    confidence_interval: 0.0455
-    average: 2.4071
-    sample_size: 62
+    confidence_interval: 0.04743
+    average: 2.4052
+    sample_size: 88
   llama-3_1-8b-scan-offload:
     name: Llama 3.1 8B (Scan + Offload)
-    step_time_lower_bound: 2.74448761
+    step_time_lower_bound: 2.74174618
     step_time_upper_bound: 2.857276
-    confidence_interval: 0.05639
-    average: 2.8009
-    sample_size: 62
+    confidence_interval: 0.05776
+    average: 2.7995
+    sample_size: 88
   llama-3-8b-2d:
     name: Llama 3.0 8B (2D sharding)
-    step_time_lower_bound: 3.28890483
-    step_time_upper_bound: 3.38907452
-    confidence_interval: 0.05008
-    average: 3.339
-    sample_size: 62
+    step_time_lower_bound: 3.28929215
+    step_time_upper_bound: 3.38947363
+    confidence_interval: 0.05009
+    average: 3.3394
+    sample_size: 81
   mixtral-8x7b:
     name: Mixtral 8x7B
-    step_time_lower_bound: 3.10035046
-    step_time_upper_bound: 3.19477738
-    confidence_interval: 0.04721
-    average: 3.1476
-    sample_size: 62
+    step_time_lower_bound: 3.09970013
+    step_time_upper_bound: 3.19410724
+    confidence_interval: 0.0472
+    average: 3.1469
+    sample_size: 88
   llama-3-8b-2-slice:
     name: Llama 3.0 8B (2 Slice)
-    step_time_lower_bound: 3.87527939
+    step_time_lower_bound: 3.87682821
     step_time_upper_bound: 4.026164
-    confidence_interval: 0.07544
-    average: 3.9507
-    sample_size: 62
+    confidence_interval: 0.07467
+    average: 3.9515
+    sample_size: 75
 metadata:
   query_start: 2025-05-29 17:52:00 America/Los_Angeles
   query_end: 2025-06-02 17:52:00 America/Los_Angeles

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -1,47 +1,47 @@
 benchmarks:
   llama-3-8b:
     name: Llama 3.0 8B
-    step_time_lower_bound: 2.67975625
+    step_time_lower_bound: 2.6772919
     step_time_upper_bound: 2.788876
-    confidence_interval: 0.05456
-    average: 2.7343
-    sample_size: 104
+    confidence_interval: 0.05579
+    average: 2.7331
+    sample_size: 145
   llama-3_1-8b-sa:
     name: Llama 3.1 8B (Splash Attention)
-    step_time_lower_bound: 2.35893329
+    step_time_lower_bound: 2.3596336
     step_time_upper_bound: 2.452628
-    confidence_interval: 0.04685
-    average: 2.4058
-    sample_size: 104
+    confidence_interval: 0.0465
+    average: 2.4061
+    sample_size: 145
   llama-3_1-8b-scan-offload:
     name: Llama 3.1 8B (Scan + Offload)
-    step_time_lower_bound: 2.73966392
-    step_time_upper_bound: 2.857276
-    confidence_interval: 0.05881
-    average: 2.7985
-    sample_size: 104
+    step_time_lower_bound: 2.73950752
+    step_time_upper_bound: 2.85849
+    confidence_interval: 0.05949
+    average: 2.799
+    sample_size: 145
   llama-3-8b-2d:
     name: Llama 3.0 8B (2D sharding)
-    step_time_lower_bound: 3.2893677
-    step_time_upper_bound: 3.38955149
+    step_time_lower_bound: 3.28906594
+    step_time_upper_bound: 3.38924054
     confidence_interval: 0.05009
-    average: 3.3395
-    sample_size: 104
+    average: 3.3392
+    sample_size: 145
   mixtral-8x7b:
     name: Mixtral 8x7B
-    step_time_lower_bound: 3.09912397
-    step_time_upper_bound: 3.19351353
+    step_time_lower_bound: 3.09896717
+    step_time_upper_bound: 3.19335196
     confidence_interval: 0.04719
-    average: 3.1463
-    sample_size: 104
+    average: 3.1462
+    sample_size: 145
   llama-3-8b-2-slice:
     name: Llama 3.0 8B (2 Slice)
-    step_time_lower_bound: 3.88106931
+    step_time_lower_bound: 3.88394539
     step_time_upper_bound: 4.026164
-    confidence_interval: 0.07255
-    average: 3.9536
-    sample_size: 104
+    confidence_interval: 0.07111
+    average: 3.9551
+    sample_size: 145
 metadata:
   query_start: 2025-05-29 17:52:00 America/Los_Angeles
-  query_end: 2025-06-02 17:52:00 America/Los_Angeles
+  query_end: 2025-06-01 20:00:00 America/Los_Angeles
   confidence_level: 0.999

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -7,9 +7,12 @@ related to the `pytorch_torchprime` software ID within a specific date range.
 """
 
 import json
+from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 import scipy
+import yaml
 from google.cloud import bigquery
 from rich.console import Console
 from rich.table import Table
@@ -82,7 +85,8 @@ def match_llama3_8b_2d(row):
 
 
 def match_mixtral(row):
-  return row.run_id.startswith("mixtral-8x7b-")
+  config = json.loads(row.configs_framework)
+  return row.run_id.startswith("mixtral-8x7b-") and config["ici_mesh"]["fsdp"] == 4
 
 
 def match_llama_3_8b_2_slice(row):
@@ -94,7 +98,7 @@ def match_llama_3_8b_2_slice(row):
   )
 
 
-benchmarks = {
+BENCHMARKS = {
   "Llama 3.0 8B": match_llama3_8b,
   "Llama 3.1 8B (Splash Attention)": match_llama3_1_8b_sa,
   "Llama 3.1 8B (Scan + Offload)": match_llama3_1_8b_scan_offload,
@@ -102,21 +106,7 @@ benchmarks = {
   "Mixtral 8x7B": match_mixtral,
   "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
 }
-
-step_time_by_benchmark = {}
-
-for row in rows:
-  matched = set()
-  for name, match_fn in benchmarks.items():
-    if match_fn(row):
-      matched.add(name)
-  if not matched:
-    raise ValueError(f"Run ID {row.run_id} does not match any benchmark: {matched}")
-  if len(matched) > 1:
-    raise ValueError(f"Run ID {row.run_id} matches multiple benchmarks: {matched}")
-  step_time_by_benchmark.setdefault(matched.pop(), []).append(row.metrics_step_time)
-
-step_time_by_benchmark = {name: step_time_by_benchmark[name] for name in benchmarks}
+CONFIDENCE_LEVEL = 0.999  # 99.9% confidence level
 
 
 def calculate_confidence_t_interval(alpha, stdev, count):
@@ -137,7 +127,9 @@ def calculate_confidence_t_interval(alpha, stdev, count):
   return upper_bound
 
 
-def compute_bounds(step_times):
+def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
+  """Implements the formula described in e2e_testing/README.md"""
+
   n = len(step_times)
   assert n > 1, "Not enough step times to compute bounds"
 
@@ -147,7 +139,7 @@ def compute_bounds(step_times):
 
   # Use sample standard deviation for consistency with t-distribution
   stdev = (sum((x - mean) ** 2 for x in step_times) / (n - 1)) ** 0.5
-  t_critical = calculate_confidence_t_interval(0.001, stdev, n)
+  t_critical = calculate_confidence_t_interval(1 - confidence_level, stdev, n)
 
   # Calculate the half-width H
   H = max(
@@ -163,6 +155,22 @@ def compute_bounds(step_times):
   return lower_bound, upper_bound
 
 
+step_time_by_benchmark = {}
+
+for row in rows:
+  matched = set()
+  for name, match_fn in BENCHMARKS.items():
+    if match_fn(row):
+      matched.add(name)
+  if not matched:
+    raise ValueError(f"Run ID {row.run_id} does not match any benchmark: {matched}")
+  if len(matched) > 1:
+    raise ValueError(f"Run ID {row.run_id} matches multiple benchmarks: {matched}")
+  step_time_by_benchmark.setdefault(matched.pop(), []).append(row.metrics_step_time)
+
+step_time_by_benchmark = {name: step_time_by_benchmark[name] for name in BENCHMARKS}
+
+
 console = Console()
 table = Table(title="Confidence Intervals for Step Time")
 
@@ -171,7 +179,7 @@ table.add_column("Runs", justify="right", style="magenta")
 table.add_column("Average (sec)", justify="right", style="green")
 table.add_column("Lower Bound", justify="right", style="green")
 table.add_column("Upper Bound", justify="right", style="green")
-table.add_column("Interval (ms)", justify="right", style="green")
+table.add_column("Range (ms)", justify="right", style="green")
 
 for name, step_times in step_time_by_benchmark.items():
   lower_bound, upper_bound = compute_bounds(step_times)
@@ -187,3 +195,56 @@ for name, step_times in step_time_by_benchmark.items():
   )
 
 console.print(table)
+
+benchmarks_data = {}
+for name, step_times in step_time_by_benchmark.items():
+  if len(step_times) <= 1:
+    console.print(
+      f"[yellow]Warning: Skipping {name} - insufficient data points[/yellow]"
+    )
+    continue
+
+  lower_bound, upper_bound = compute_bounds(step_times)
+  average = sum(step_times) / len(step_times)
+
+  # Map benchmark names to their GitHub Action job IDs
+  job_id_mapping = {
+    "Llama 3.0 8B": "llama-3-8b",
+    "Llama 3.1 8B (Splash Attention)": "llama-3_1-8b-sa",
+    "Llama 3.1 8B (Scan + Offload)": "llama-3_1-8b-scan-offload",
+    "Llama 3.0 8B (2D sharding)": "llama-3-8b-2d",
+    "Mixtral 8x7B": "mixtral-8x7b",
+    "Llama 3.0 8B (2 Slice)": "llama-3-8b-2-slice",
+  }
+
+  job_id = job_id_mapping.get(name)
+  if job_id:
+    benchmarks_data[job_id] = {
+      "name": name,
+      "step_time_lower_bound": round(lower_bound, 8),
+      "step_time_upper_bound": round(upper_bound, 8),
+      "confidence_interval": round((upper_bound - lower_bound) / 2, 5),
+      "average": round(average, 4),
+      "sample_size": len(step_times),
+    }
+
+# Write to file
+output_path = Path("e2e_testing/step_time_bounds.yaml")
+output_path.parent.mkdir(exist_ok=True)
+
+with open(output_path, "w") as f:
+  yaml.dump(
+    {
+      "benchmarks": benchmarks_data,
+      "metadata": {
+        "query_start": start_time,
+        "query_end": end_time,
+        "confidence_level": CONFIDENCE_LEVEL,
+      },
+    },
+    f,
+    default_flow_style=False,
+    sort_keys=False,
+  )
+
+console.print(f"\nPerformance bounds exported to {output_path}")

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -20,16 +20,6 @@ from rich.table import Table
 
 from torchprime.launcher.benchmark_db_util import TORCHPRIME_SOFTWARE_ID
 
-BENCHMARKS = {
-  "Llama 3.0 8B": "match_llama3_8b",
-  "Llama 3.1 8B (Splash Attention)": "match_llama3_1_8b_sa",
-  "Llama 3.1 8B (Scan + Offload)": "match_llama3_1_8b_scan_offload",
-  "Llama 3.0 8B (2D sharding)": "match_llama3_8b_2d",
-  "Mixtral 8x7B": "match_mixtral",
-  "Llama 3.0 8B (2 Slice)": "match_llama_3_8b_2_slice",
-}
-CONFIDENCE_LEVEL = 0.999  # 99.9% confidence level
-
 
 def match_llama3_8b(row):
   config = json.loads(row.configs_framework)
@@ -80,6 +70,18 @@ def match_llama_3_8b_2_slice(row):
     and config["dcn_mesh"]["fsdp"] == 2
     and config["ici_mesh"]["fsdp"] == 4
   )
+
+
+BENCHMARKS = {
+  "Llama 3.0 8B": match_llama3_8b,
+  "Llama 3.1 8B (Splash Attention)": match_llama3_1_8b_sa,
+  "Llama 3.1 8B (Scan + Offload)": match_llama3_1_8b_scan_offload,
+  "Llama 3.0 8B (2D sharding)": match_llama3_8b_2d,
+  "Mixtral 8x7B": match_mixtral,
+  "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
+}
+
+CONFIDENCE_LEVEL = 0.999  # 99.9% confidence level
 
 
 def parse_datetime(datetime_str):
@@ -141,8 +143,7 @@ def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
   min_time = min(step_times)
   max_time = max(step_times)
 
-  # Use sample standard deviation for consistency with t-distribution
-  stdev = (sum((x - mean) ** 2 for x in step_times) / (n - 1)) ** 0.5
+  stdev = np.std(step_times, ddof=1)
   t_critical = calculate_confidence_t_interval(1 - confidence_level, stdev, n)
 
   # Calculate the half-width H
@@ -189,7 +190,7 @@ def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
 )
 @click.option(
   "--limit",
-  default=1000,
+  default=1200,
   type=int,
   help="Maximum number of rows to retrieve",
 )
@@ -247,19 +248,9 @@ def main(bq_project, bq_dataset, bq_table, start_time, end_time, limit, output):
   # Group rows by benchmark
   step_time_by_benchmark = {}
 
-  # Create match function mapping
-  match_functions = {
-    "Llama 3.0 8B": match_llama3_8b,
-    "Llama 3.1 8B (Splash Attention)": match_llama3_1_8b_sa,
-    "Llama 3.1 8B (Scan + Offload)": match_llama3_1_8b_scan_offload,
-    "Llama 3.0 8B (2D sharding)": match_llama3_8b_2d,
-    "Mixtral 8x7B": match_mixtral,
-    "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
-  }
-
   for row in rows:
     matched = set()
-    for name, match_fn in match_functions.items():
+    for name, match_fn in BENCHMARKS.items():
       if match_fn(row):
         matched.add(name)
 

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -25,7 +25,7 @@ dataset = "benchmark_dataset_test"
 table = "torchprime-e2e-tests"
 start_time = "2025-05-29 17:52:00 America/Los_Angeles"
 end_time = "2025-06-02 17:52:00 America/Los_Angeles"
-limit = 750
+limit = 800
 
 QUERY = f"""
 -- Find the most recent rows based on update_timestamp and sort them by most recent first

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -7,9 +7,10 @@ the results to a YAML file for use in GitHub Actions.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
+import re
 import click
 import numpy as np
 import scipy
@@ -81,7 +82,34 @@ BENCHMARKS = {
   "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
 }
 
+STEP_ID_MAPPING = {
+  "Llama 3.0 8B": "llama-3-8b",
+  "Llama 3.1 8B (Splash Attention)": "llama-3_1-8b-sa",
+  "Llama 3.1 8B (Scan + Offload)": "llama-3_1-8b-scan-offload",
+  "Llama 3.0 8B (2D sharding)": "llama-3-8b-2d",
+  "Mixtral 8x7B": "mixtral-8x7b",
+  "Llama 3.0 8B (2 Slice)": "llama-3-8b-2-slice",
+}
+"""Mapping from the benchmark name to the ID of the E2E test step used in GitHub Actions."""
+
 CONFIDENCE_LEVEL = 0.999  # 99.9% confidence level
+
+
+def parse_days_ago(days_str: str):
+  """Parse a string like '2 days ago' and return a datetime object."""
+  match = re.match(r"(\d+)\s+days?\s+ago", days_str.strip())
+  if not match or len(match.groups()) != 1:
+    raise ValueError(f"Invalid days ago format: {days_str}")
+  days = int(match.group(1))
+  return datetime.now() - timedelta(days=days)
+
+
+def render_local_datetime_utc(dt):
+  """Render a local datetime object in UTC timezone."""
+  local_tz = datetime.now().astimezone().tzinfo
+  dt = dt.replace(tzinfo=local_tz)
+  dt_utc = dt.astimezone(datetime.utcnow().tzinfo)
+  return dt_utc.isoformat()
 
 
 def parse_datetime(datetime_str):
@@ -94,6 +122,10 @@ def parse_datetime(datetime_str):
   if "/" in datetime_str or " UTC" in datetime_str:
     return datetime_str
 
+  # Then check if it's in 'N days ago' format
+  if "days ago" in datetime_str:
+    return render_local_datetime_utc(parse_days_ago(datetime_str))
+
   # Try common datetime formats and convert to GoogleSQL format
   formats = [
     "%Y-%m-%d %H:%M:%S",
@@ -103,13 +135,10 @@ def parse_datetime(datetime_str):
     "%m/%d/%Y",
   ]
 
-  local_tz = datetime.now().astimezone().tzinfo
   for fmt in formats:
     try:
       dt = datetime.strptime(datetime_str, fmt)
-      dt = dt.replace(tzinfo=local_tz)
-      dt_utc = dt.astimezone(datetime.utcnow().tzinfo)
-      return dt_utc.isoformat()
+      return render_local_datetime_utc(dt)
     except ValueError:
       continue
 
@@ -128,8 +157,10 @@ def calculate_confidence_t_interval(alpha, stdev, count):
 
   df = count - 1
   confidence_level = 1 - alpha
-  sem = stdev / np.sqrt(count)
-  _, upper_bound = scipy.stats.t.interval(confidence_level, df, loc=0, scale=sem)
+  standard_error = stdev / np.sqrt(count)
+  _, upper_bound = scipy.stats.t.interval(
+    confidence_level, df, loc=0, scale=standard_error
+  )
 
   return upper_bound
 
@@ -178,15 +209,19 @@ def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
 )
 @click.option(
   "--start-time",
-  default="2025-05-29 17:52:00 America/Los_Angeles",
+  default=parse_days_ago("5 days ago").strftime("%Y-%m-%d %H:%M:%S"),
   help="Start time for the query in GoogleSQL datetime format (e.g., '2025-05-29 17:52:00 America/Los_Angeles'). "
-  "Can also accept common datetime formats which will be converted.",
+  "Can also accept common datetime formats which will be converted. "
+  "In particular, supports '[N] days ago' format, e.g., '2 days ago'. "
+  "Defaults to 5 days ago.",
 )
 @click.option(
   "--end-time",
-  default="2025-06-01 20:00:00 America/Los_Angeles",
+  default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
   help="End time for the query in GoogleSQL datetime format (e.g., '2025-06-01 20:00:00 America/Los_Angeles'). "
-  "Can also accept common datetime formats which will be converted.",
+  "Can also accept common datetime formats which will be converted. "
+  "In particular, supports '[N] days ago' format, e.g., '2 days ago'. "
+  "Defaults to the current time.",
 )
 @click.option(
   "--limit",
@@ -277,14 +312,6 @@ def main(bq_project, bq_dataset, bq_table, start_time, end_time, limit, output):
   table.add_column("Range (ms)", justify="right", style="green")
 
   benchmarks_data = {}
-  job_id_mapping = {
-    "Llama 3.0 8B": "llama-3-8b",
-    "Llama 3.1 8B (Splash Attention)": "llama-3_1-8b-sa",
-    "Llama 3.1 8B (Scan + Offload)": "llama-3_1-8b-scan-offload",
-    "Llama 3.0 8B (2D sharding)": "llama-3-8b-2d",
-    "Mixtral 8x7B": "mixtral-8x7b",
-    "Llama 3.0 8B (2 Slice)": "llama-3-8b-2-slice",
-  }
 
   for name, step_times in step_time_by_benchmark.items():
     lower_bound, upper_bound = compute_bounds(step_times)
@@ -300,7 +327,7 @@ def main(bq_project, bq_dataset, bq_table, start_time, end_time, limit, output):
       f"{interval_ms:.1f}",
     )
 
-    job_id = job_id_mapping.get(name)
+    job_id = STEP_ID_MAPPING.get(name)
     if job_id:
       benchmarks_data[job_id] = {
         "name": name,

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""
-This script is used to query the `torchprime-e2e-tests` table in the
-`benchmark_dataset_test` dataset of the `tpu-pytorch` project. It retrieves the
-most recent rows based on the `update_timestamp` field, filtering for entries
-related to the `pytorch_torchprime` software ID within a specific date range.
+"""Query BigQuery for E2E test results and compute step time bounds.
+
+This script queries the specified BigQuery table for recent test results,
+computes statistical bounds for each benchmark's step times, and exports
+the results to a YAML file for use in GitHub Actions.
 """
 
 import json
@@ -83,41 +83,36 @@ def match_llama_3_8b_2_slice(row):
 
 
 def parse_datetime(datetime_str):
-  """
-  Parse datetime string. First tries GoogleSQL format with timezone,
-  then falls back to Python datetime parsing and converts to GoogleSQL format.
+  """Parse datetime string.
+
+  First tries GoogleSQL format with timezone, then falls back to Python datetime
+  parsing and converts to GoogleSQL format.
   """
   # First check if it's already in GoogleSQL format (has timezone)
-  if " America/" in datetime_str or " UTC" in datetime_str:
+  if "/" in datetime_str or " UTC" in datetime_str:
     return datetime_str
 
   # Try common datetime formats and convert to GoogleSQL format
   formats = [
     "%Y-%m-%d %H:%M:%S",
-    "%Y-%m-%dT%H:%M:%S",
     "%Y-%m-%d %H:%M",
     "%Y-%m-%d",
     "%m/%d/%Y %H:%M:%S",
     "%m/%d/%Y",
   ]
 
+  local_tz = datetime.now().astimezone().tzinfo
   for fmt in formats:
     try:
       dt = datetime.strptime(datetime_str, fmt)
-      # Convert to GoogleSQL format with Pacific timezone
-      return f"{dt.strftime('%Y-%m-%d %H:%M:%S')} America/Los_Angeles"
+      dt = dt.replace(tzinfo=local_tz)
+      dt_utc = dt.astimezone(datetime.utcnow().tzinfo)
+      return dt_utc.isoformat()
     except ValueError:
       continue
 
-  # If all else fails, try dateutil parser
-  try:
-    from dateutil import parser
-
-    dt = parser.parse(datetime_str)
-    return f"{dt.strftime('%Y-%m-%d %H:%M:%S')} America/Los_Angeles"
-  except:
-    # Return as-is and let BigQuery handle the error
-    return datetime_str
+  # Return as-is and let BigQuery handle it
+  return datetime_str
 
 
 def calculate_confidence_t_interval(alpha, stdev, count):
@@ -184,13 +179,13 @@ def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
   "--start-time",
   default="2025-05-29 17:52:00 America/Los_Angeles",
   help="Start time for the query in GoogleSQL datetime format (e.g., '2025-05-29 17:52:00 America/Los_Angeles'). "
-  "Can also accept common datetime formats which will be converted to Pacific timezone.",
+  "Can also accept common datetime formats which will be converted.",
 )
 @click.option(
   "--end-time",
-  default="2025-06-02 17:52:00 America/Los_Angeles",
-  help="End time for the query in GoogleSQL datetime format (e.g., '2025-06-02 17:52:00 America/Los_Angeles'). "
-  "Can also accept common datetime formats which will be converted to Pacific timezone.",
+  default="2025-06-01 20:00:00 America/Los_Angeles",
+  help="End time for the query in GoogleSQL datetime format (e.g., '2025-06-01 20:00:00 America/Los_Angeles'). "
+  "Can also accept common datetime formats which will be converted.",
 )
 @click.option(
   "--limit",

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -7,10 +7,10 @@ the results to a YAML file for use in GitHub Actions.
 """
 
 import json
+import re
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import re
 import click
 import numpy as np
 import scipy

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -7,8 +7,10 @@ related to the `pytorch_torchprime` software ID within a specific date range.
 """
 
 import json
+from datetime import datetime
 from pathlib import Path
 
+import click
 import numpy as np
 import scipy
 import yaml
@@ -18,32 +20,15 @@ from rich.table import Table
 
 from torchprime.launcher.benchmark_db_util import TORCHPRIME_SOFTWARE_ID
 
-client = bigquery.Client()
-
-project = "tpu-pytorch"
-dataset = "benchmark_dataset_test"
-table = "torchprime-e2e-tests"
-start_time = "2025-05-29 17:52:00 America/Los_Angeles"
-end_time = "2025-06-02 17:52:00 America/Los_Angeles"
-limit = 800
-
-QUERY = f"""
--- Find the most recent rows based on update_timestamp and sort them by most recent first
-SELECT
-  *
-FROM
-  `{project}`.`{dataset}`.`{table}`
-WHERE
-  software_id = '{TORCHPRIME_SOFTWARE_ID}' AND
-  update_timestamp >= TIMESTAMP('{start_time}') AND
-  update_timestamp <= TIMESTAMP('{end_time}')
-ORDER BY
-  update_timestamp DESC
-LIMIT
-  {limit};
-"""
-query_job = client.query(QUERY)
-rows = list(query_job.result())
+BENCHMARKS = {
+  "Llama 3.0 8B": "match_llama3_8b",
+  "Llama 3.1 8B (Splash Attention)": "match_llama3_1_8b_sa",
+  "Llama 3.1 8B (Scan + Offload)": "match_llama3_1_8b_scan_offload",
+  "Llama 3.0 8B (2D sharding)": "match_llama3_8b_2d",
+  "Mixtral 8x7B": "match_mixtral",
+  "Llama 3.0 8B (2 Slice)": "match_llama_3_8b_2_slice",
+}
+CONFIDENCE_LEVEL = 0.999  # 99.9% confidence level
 
 
 def match_llama3_8b(row):
@@ -97,20 +82,46 @@ def match_llama_3_8b_2_slice(row):
   )
 
 
-BENCHMARKS = {
-  "Llama 3.0 8B": match_llama3_8b,
-  "Llama 3.1 8B (Splash Attention)": match_llama3_1_8b_sa,
-  "Llama 3.1 8B (Scan + Offload)": match_llama3_1_8b_scan_offload,
-  "Llama 3.0 8B (2D sharding)": match_llama3_8b_2d,
-  "Mixtral 8x7B": match_mixtral,
-  "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
-}
-CONFIDENCE_LEVEL = 0.999  # 99.9% confidence level
+def parse_datetime(datetime_str):
+  """
+  Parse datetime string. First tries GoogleSQL format with timezone,
+  then falls back to Python datetime parsing and converts to GoogleSQL format.
+  """
+  # First check if it's already in GoogleSQL format (has timezone)
+  if " America/" in datetime_str or " UTC" in datetime_str:
+    return datetime_str
+
+  # Try common datetime formats and convert to GoogleSQL format
+  formats = [
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%d",
+    "%m/%d/%Y %H:%M:%S",
+    "%m/%d/%Y",
+  ]
+
+  for fmt in formats:
+    try:
+      dt = datetime.strptime(datetime_str, fmt)
+      # Convert to GoogleSQL format with Pacific timezone
+      return f"{dt.strftime('%Y-%m-%d %H:%M:%S')} America/Los_Angeles"
+    except ValueError:
+      continue
+
+  # If all else fails, try dateutil parser
+  try:
+    from dateutil import parser
+
+    dt = parser.parse(datetime_str)
+    return f"{dt.strftime('%Y-%m-%d %H:%M:%S')} America/Los_Angeles"
+  except:
+    # Return as-is and let BigQuery handle the error
+    return datetime_str
 
 
 def calculate_confidence_t_interval(alpha, stdev, count):
   """Calculate margin of error using t-distribution."""
-
   if count <= 1 or stdev < 0:
     raise ValueError(
       f"Invalid parameters for t-distribution: count={count}, stdev={stdev}"
@@ -128,7 +139,6 @@ def calculate_confidence_t_interval(alpha, stdev, count):
 
 def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
   """Implements the formula described in e2e_testing/README.md"""
-
   n = len(step_times)
   assert n > 1, "Not enough step times to compute bounds"
 
@@ -154,59 +164,133 @@ def compute_bounds(step_times, confidence_level=CONFIDENCE_LEVEL):
   return lower_bound, upper_bound
 
 
-step_time_by_benchmark = {}
+@click.command()
+@click.option(
+  "--bq-project",
+  default="tpu-pytorch",
+  help="BigQuery project ID",
+)
+@click.option(
+  "--bq-dataset",
+  default="benchmark_dataset_test",
+  help="BigQuery dataset name",
+)
+@click.option(
+  "--bq-table",
+  default="torchprime-e2e-tests",
+  help="BigQuery table name",
+)
+@click.option(
+  "--start-time",
+  default="2025-05-29 17:52:00 America/Los_Angeles",
+  help="Start time for the query in GoogleSQL datetime format (e.g., '2025-05-29 17:52:00 America/Los_Angeles'). "
+  "Can also accept common datetime formats which will be converted to Pacific timezone.",
+)
+@click.option(
+  "--end-time",
+  default="2025-06-02 17:52:00 America/Los_Angeles",
+  help="End time for the query in GoogleSQL datetime format (e.g., '2025-06-02 17:52:00 America/Los_Angeles'). "
+  "Can also accept common datetime formats which will be converted to Pacific timezone.",
+)
+@click.option(
+  "--limit",
+  default=1000,
+  type=int,
+  help="Maximum number of rows to retrieve",
+)
+@click.option(
+  "--output",
+  default="e2e_testing/step_time_bounds.yaml",
+  type=click.Path(),
+  help="Output YAML file path",
+)
+def main(bq_project, bq_dataset, bq_table, start_time, end_time, limit, output):
+  """
+  Query BigQuery for E2E test results and compute step time bounds.
 
-for row in rows:
-  matched = set()
-  for name, match_fn in BENCHMARKS.items():
-    if match_fn(row):
-      matched.add(name)
-  if not matched:
-    raise ValueError(f"Run ID {row.run_id} does not match any benchmark: {matched}")
-  if len(matched) > 1:
-    raise ValueError(f"Run ID {row.run_id} matches multiple benchmarks: {matched}")
-  step_time_by_benchmark.setdefault(matched.pop(), []).append(row.metrics_step_time)
+  This script queries the specified BigQuery table for recent test results,
+  computes statistical bounds for each benchmark's step times, and exports
+  the results to a YAML file for use in GitHub Actions.
+  """
+  console = Console()
 
-step_time_by_benchmark = {name: step_time_by_benchmark[name] for name in BENCHMARKS}
+  # Parse datetime inputs
+  start_time = parse_datetime(start_time)
+  end_time = parse_datetime(end_time)
 
+  console.print("[bold]Querying BigQuery:[/bold]")
+  console.print(f"  Project: {bq_project}")
+  console.print(f"  Dataset: {bq_dataset}")
+  console.print(f"  Table: {bq_table}")
+  console.print(f"  Start: {start_time}")
+  console.print(f"  End: {end_time}")
+  console.print(f"  Limit: {limit}")
 
-console = Console()
-table = Table(title="Confidence Intervals for Step Time")
+  client = bigquery.Client()
 
-table.add_column("Benchmark", justify="right", style="cyan", no_wrap=True)
-table.add_column("Runs", justify="right", style="magenta")
-table.add_column("Average (sec)", justify="right", style="green")
-table.add_column("Lower Bound", justify="right", style="green")
-table.add_column("Upper Bound", justify="right", style="green")
-table.add_column("Range (ms)", justify="right", style="green")
+  query = f"""
+  -- Find the most recent rows based on update_timestamp and sort them by most recent first
+  SELECT
+    *
+  FROM
+    `{bq_project}`.`{bq_dataset}`.`{bq_table}`
+  WHERE
+    software_id = '{TORCHPRIME_SOFTWARE_ID}' AND
+    update_timestamp >= TIMESTAMP('{start_time}') AND
+    update_timestamp <= TIMESTAMP('{end_time}')
+  ORDER BY
+    update_timestamp DESC
+  LIMIT
+    {limit};
+  """
 
-for name, step_times in step_time_by_benchmark.items():
-  lower_bound, upper_bound = compute_bounds(step_times)
-  average = sum(step_times) / len(step_times)
-  interval_ms = (upper_bound - lower_bound) * 1000
-  table.add_row(
-    name,
-    f"{len(step_times)}",
-    f"{average:.2f}",
-    f"{lower_bound:.4f}",
-    f"{upper_bound:.4f}",
-    f"{interval_ms:.1f}",
-  )
+  query_job = client.query(query)
+  rows = list(query_job.result())
 
-console.print(table)
+  console.print(f"\n[green]Retrieved {len(rows)} rows[/green]\n")
 
-benchmarks_data = {}
-for name, step_times in step_time_by_benchmark.items():
-  if len(step_times) <= 1:
-    console.print(
-      f"[yellow]Warning: Skipping {name} - insufficient data points[/yellow]"
-    )
-    continue
+  # Group rows by benchmark
+  step_time_by_benchmark = {}
 
-  lower_bound, upper_bound = compute_bounds(step_times)
-  average = sum(step_times) / len(step_times)
+  # Create match function mapping
+  match_functions = {
+    "Llama 3.0 8B": match_llama3_8b,
+    "Llama 3.1 8B (Splash Attention)": match_llama3_1_8b_sa,
+    "Llama 3.1 8B (Scan + Offload)": match_llama3_1_8b_scan_offload,
+    "Llama 3.0 8B (2D sharding)": match_llama3_8b_2d,
+    "Mixtral 8x7B": match_mixtral,
+    "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
+  }
 
-  # Map benchmark names to their GitHub Action job IDs
+  for row in rows:
+    matched = set()
+    for name, match_fn in match_functions.items():
+      if match_fn(row):
+        matched.add(name)
+
+    if not matched:
+      raise ValueError(f"Run ID {row.run_id} does not match any benchmark")
+
+    if len(matched) > 1:
+      raise ValueError(f"Run ID {row.run_id} matches multiple benchmarks: {matched}")
+
+    step_time_by_benchmark.setdefault(matched.pop(), []).append(row.metrics_step_time)
+
+  # Ensure all benchmarks are represented
+  step_time_by_benchmark = {
+    name: step_time_by_benchmark.get(name, []) for name in BENCHMARKS
+  }
+
+  # Display results table
+  table = Table(title="Confidence Intervals for Step Time")
+  table.add_column("Benchmark", justify="right", style="cyan", no_wrap=True)
+  table.add_column("Runs", justify="right", style="magenta")
+  table.add_column("Average (sec)", justify="right", style="green")
+  table.add_column("Lower Bound", justify="right", style="green")
+  table.add_column("Upper Bound", justify="right", style="green")
+  table.add_column("Range (ms)", justify="right", style="green")
+
+  benchmarks_data = {}
   job_id_mapping = {
     "Llama 3.0 8B": "llama-3-8b",
     "Llama 3.1 8B (Splash Attention)": "llama-3_1-8b-sa",
@@ -216,34 +300,54 @@ for name, step_times in step_time_by_benchmark.items():
     "Llama 3.0 8B (2 Slice)": "llama-3-8b-2-slice",
   }
 
-  job_id = job_id_mapping.get(name)
-  if job_id:
-    benchmarks_data[job_id] = {
-      "name": name,
-      "step_time_lower_bound": round(lower_bound, 8),
-      "step_time_upper_bound": round(upper_bound, 8),
-      "confidence_interval": round((upper_bound - lower_bound) / 2, 5),
-      "average": round(average, 4),
-      "sample_size": len(step_times),
-    }
+  for name, step_times in step_time_by_benchmark.items():
+    lower_bound, upper_bound = compute_bounds(step_times)
+    average = sum(step_times) / len(step_times)
+    interval_ms = (upper_bound - lower_bound) * 1000
 
-# Write to file
-output_path = Path("e2e_testing/step_time_bounds.yaml")
-output_path.parent.mkdir(exist_ok=True)
+    table.add_row(
+      name,
+      f"{len(step_times)}",
+      f"{average:.2f}",
+      f"{lower_bound:.4f}",
+      f"{upper_bound:.4f}",
+      f"{interval_ms:.1f}",
+    )
 
-with open(output_path, "w") as f:
-  yaml.dump(
-    {
-      "benchmarks": benchmarks_data,
-      "metadata": {
-        "query_start": start_time,
-        "query_end": end_time,
-        "confidence_level": CONFIDENCE_LEVEL,
+    job_id = job_id_mapping.get(name)
+    if job_id:
+      benchmarks_data[job_id] = {
+        "name": name,
+        "step_time_lower_bound": round(lower_bound, 8),
+        "step_time_upper_bound": round(upper_bound, 8),
+        "confidence_interval": round((upper_bound - lower_bound) / 2, 5),
+        "average": round(average, 4),
+        "sample_size": len(step_times),
+      }
+
+  console.print(table)
+
+  # Write to file
+  output_path = Path(output)
+  output_path.parent.mkdir(exist_ok=True, parents=True)
+
+  with open(output_path, "w") as f:
+    yaml.dump(
+      {
+        "benchmarks": benchmarks_data,
+        "metadata": {
+          "query_start": start_time,
+          "query_end": end_time,
+          "confidence_level": CONFIDENCE_LEVEL,
+        },
       },
-    },
-    f,
-    default_flow_style=False,
-    sort_keys=False,
-  )
+      f,
+      default_flow_style=False,
+      sort_keys=False,
+    )
 
-console.print(f"\nPerformance bounds exported to {output_path}")
+  console.print(f"\n[green]Performance bounds exported to {output_path}[/green]")
+
+
+if __name__ == "__main__":
+  main()

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -7,7 +7,6 @@ related to the `pytorch_torchprime` software ID within a specific date range.
 """
 
 import json
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+This script is used to query the `torchprime-e2e-tests` table in the
+`benchmark_dataset_test` dataset of the `tpu-pytorch` project. It retrieves the
+most recent rows based on the `update_timestamp` field, filtering for entries
+related to the `pytorch_torchprime` software ID within a specific date range.
+"""
+
+import json
+
+import numpy as np
+import scipy
+from google.cloud import bigquery
+from rich.console import Console
+from rich.table import Table
+
+from torchprime.launcher.benchmark_db_util import TORCHPRIME_SOFTWARE_ID
+
+client = bigquery.Client()
+
+project = "tpu-pytorch"
+dataset = "benchmark_dataset_test"
+table = "torchprime-e2e-tests"
+start_time = "2025-05-29 17:52:00 America/Los_Angeles"
+end_time = "2025-06-02 17:52:00 America/Los_Angeles"
+limit = 750
+
+QUERY = f"""
+-- Find the most recent rows based on update_timestamp and sort them by most recent first
+SELECT
+  *
+FROM
+  `{project}`.`{dataset}`.`{table}`
+WHERE
+  software_id = '{TORCHPRIME_SOFTWARE_ID}' AND
+  update_timestamp >= TIMESTAMP('{start_time}') AND
+  update_timestamp <= TIMESTAMP('{end_time}')
+ORDER BY
+  update_timestamp DESC
+LIMIT
+  {limit};
+"""
+query_job = client.query(QUERY)
+rows = list(query_job.result())
+
+
+def match_llama3_8b(row):
+  config = json.loads(row.configs_framework)
+  return (
+    row.run_id.startswith("llama-3-8b-")
+    and config["dcn_mesh"]["fsdp"] == 1
+    and config["ici_mesh"]["tensor"] == 1
+  )
+
+
+def match_llama3_1_8b_sa(row):
+  config = json.loads(row.configs_framework)
+  return (
+    row.run_id.startswith("llama-3dot1-8b-sa")
+    and config["model"]["attention_kernel"] == "splash_attention"
+  )
+
+
+def match_llama3_1_8b_scan_offload(row):
+  config = json.loads(row.configs_framework)
+  return (
+    row.run_id.startswith("llama-3dot1-8b-")
+    and config["model"]["remat"]["scan_layers"] == "model.layers"
+    and config["dcn_mesh"]["fsdp"] == 1
+    and config["ici_mesh"]["tensor"] == 1
+  )
+
+
+def match_llama3_8b_2d(row):
+  config = json.loads(row.configs_framework)
+  return (
+    row.run_id.startswith("llama-3-8b-2d")
+    and config["dcn_mesh"]["fsdp"] == 1
+    and config["ici_mesh"]["fsdp"] == 2
+    and config["ici_mesh"]["tensor"] == 2
+  )
+
+
+def match_mixtral(row):
+  return row.run_id.startswith("mixtral-8x7b-")
+
+
+def match_llama_3_8b_2_slice(row):
+  config = json.loads(row.configs_framework)
+  return (
+    row.run_id.startswith("llama-3-8b-2-slice")
+    and config["dcn_mesh"]["fsdp"] == 2
+    and config["ici_mesh"]["fsdp"] == 4
+  )
+
+
+benchmarks = {
+  "Llama 3.0 8B": match_llama3_8b,
+  "Llama 3.1 8B (Splash Attention)": match_llama3_1_8b_sa,
+  "Llama 3.1 8B (Scan + Offload)": match_llama3_1_8b_scan_offload,
+  "Llama 3.0 8B (2D sharding)": match_llama3_8b_2d,
+  "Mixtral 8x7B": match_mixtral,
+  "Llama 3.0 8B (2 Slice)": match_llama_3_8b_2_slice,
+}
+
+step_time_by_benchmark = {}
+
+for row in rows:
+  matched = set()
+  for name, match_fn in benchmarks.items():
+    if match_fn(row):
+      matched.add(name)
+  if not matched:
+    raise ValueError(f"Run ID {row.run_id} does not match any benchmark: {matched}")
+  if len(matched) > 1:
+    raise ValueError(f"Run ID {row.run_id} matches multiple benchmarks: {matched}")
+  step_time_by_benchmark.setdefault(matched.pop(), []).append(row.metrics_step_time)
+
+step_time_by_benchmark = {name: step_time_by_benchmark[name] for name in benchmarks}
+
+
+def calculate_confidence_t_interval(alpha, stdev, count):
+  """Calculate margin of error using t-distribution."""
+
+  if count <= 1 or stdev < 0:
+    raise ValueError(
+      f"Invalid parameters for t-distribution: count={count}, stdev={stdev}"
+    )
+  if stdev == 0:
+    return 0.0
+
+  df = count - 1
+  confidence_level = 1 - alpha
+  sem = stdev / np.sqrt(count)
+  _, upper_bound = scipy.stats.t.interval(confidence_level, df, loc=0, scale=sem)
+
+  return upper_bound
+
+
+def compute_bounds(step_times):
+  n = len(step_times)
+  assert n > 1, "Not enough step times to compute bounds"
+
+  mean = sum(step_times) / n
+  min_time = min(step_times)
+  max_time = max(step_times)
+
+  # Use sample standard deviation for consistency with t-distribution
+  stdev = (sum((x - mean) ** 2 for x in step_times) / (n - 1)) ** 0.5
+  t_critical = calculate_confidence_t_interval(0.001, stdev, n)
+
+  # Calculate the half-width H
+  H = max(
+    t_critical,
+    0.015 * mean,
+    max_time - mean,
+    mean - min_time,
+  )
+
+  lower_bound: float = max(0, mean - H)
+  upper_bound: float = mean + H
+
+  return lower_bound, upper_bound
+
+
+console = Console()
+table = Table(title="Confidence Intervals for Step Time")
+
+table.add_column("Benchmark", justify="right", style="cyan", no_wrap=True)
+table.add_column("Runs", justify="right", style="magenta")
+table.add_column("Average (sec)", justify="right", style="green")
+table.add_column("Lower Bound", justify="right", style="green")
+table.add_column("Upper Bound", justify="right", style="green")
+table.add_column("Interval (ms)", justify="right", style="green")
+
+for name, step_times in step_time_by_benchmark.items():
+  lower_bound, upper_bound = compute_bounds(step_times)
+  average = sum(step_times) / len(step_times)
+  interval_ms = (upper_bound - lower_bound) * 1000
+  table.add_row(
+    name,
+    f"{len(step_times)}",
+    f"{average:.2f}",
+    f"{lower_bound:.4f}",
+    f"{upper_bound:.4f}",
+    f"{interval_ms:.1f}",
+  )
+
+console.print(table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "dataclasses-json~=0.6.7",
     "watchdog~=6.0.0",
     "pathspec~=0.12.1",
+    "pyyaml~=6.0.2",
     "rich~=14.0.0",
     "tomli~=2.2.1",
     "xpk@git+https://github.com/AI-Hypercomputer/xpk@e52a5f4cd56ad50aeab06d55100cf4d3abc4c2c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pathspec~=0.12.1",
     "pyyaml~=6.0.2",
     "rich~=14.0.0",
+    "scipy~=1.15.2",
     "tomli~=2.2.1",
     "xpk@git+https://github.com/AI-Hypercomputer/xpk@e52a5f4cd56ad50aeab06d55100cf4d3abc4c2c8"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "dataclasses-json~=0.6.7",
     "watchdog~=6.0.0",
     "pathspec~=0.12.1",
+    "rich~=14.0.0",
     "tomli~=2.2.1",
     "xpk@git+https://github.com/AI-Hypercomputer/xpk@e52a5f4cd56ad50aeab06d55100cf4d3abc4c2c8"
 ]

--- a/torchprime/launcher/benchmark_db_util.py
+++ b/torchprime/launcher/benchmark_db_util.py
@@ -9,6 +9,9 @@ from omegaconf import OmegaConf
 from torchprime.metrics.metrics import Metrics
 from torchprime.metrics.mfu import get_num_chips_and_tflops_per_chip
 
+TORCHPRIME_SOFTWARE_ID = "pytorch_torchprime"
+"""The software ID used for torchprime benchmarks in the database schema."""
+
 
 def get_metrics(base_artifact_path: str, jobset_name_for_outputs: str) -> dict | None:
   """
@@ -101,6 +104,7 @@ def prepare_benchmark_summary(
   run_id = f"{jobset_name}-{current_time_str}-{unique_id_suffix}"
 
   hardware_num_chips, tflops_per_chip = get_num_chips_and_tflops_per_chip(tpu_type)
+  hardware_id = tpu_type.split("-")[0]  # Extract the TPU generation (e.g., v4, v5e)
 
   click.echo(
     f"Tpu type: {tpu_type}, hardware_num_chips: {hardware_num_chips}, tflops_per_chip: {tflops_per_chip}"
@@ -109,10 +113,8 @@ def prepare_benchmark_summary(
   return {
     "run_id": run_id,
     "result_success": (process_returncode == 0),
-    "software_id": "pytorch_torchprime",
-    "hardware_id": tpu_type.split("-")[
-      0
-    ],  # hardware_id is the TPU generation (e.g. v4, v5e)
+    "software_id": TORCHPRIME_SOFTWARE_ID,
+    "hardware_id": hardware_id,
     "hardware_num_chips": hardware_num_chips,
     **kwargs,
   }

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -381,6 +381,9 @@ def run(
 
   command = ["python", "torchprime/launcher/thunk.py"] + list(args)
 
+  if num_slices is None:
+    num_slices = config.num_slices
+
   # Forward a bunch of important env vars.
   env_forwarding = [
     arg for env_var in _DOCKER_ENV_FORWARD_LIST for arg in forward_env(env_var)
@@ -392,7 +395,7 @@ def run(
     "--env",
     f"TORCHPRIME_TPU_TYPE={config.tpu_type}",
     "--env",
-    f"TORCHPRIME_NUM_SLICES={config.num_slices}",
+    f"TORCHPRIME_NUM_SLICES={num_slices}",
     "--env",
     f"TORCHPRIME_CLUSTER={config.cluster}",
     "--env",
@@ -418,9 +421,6 @@ def run(
         f"TORCHPRIME_BQ_TABLE={config.bq_table}",
       ]
     )
-
-  if num_slices is None:
-    num_slices = config.num_slices
 
   ensure_command("xpk")
   xpk_command = (


### PR DESCRIPTION
In this PR we replace the hardcoded step time bounds with a configuration file. We also add a script to automatically pull data from BigQuery to compute the step time bounds using the existing documented formula. Finally, we run the script with:

```sh
e2e_testing/update_step_time.py
```

to generate an accurate step time bound based on results from 1014 runs.

![screenshot-2025-06-02-10-59-54](https://github.com/user-attachments/assets/dc3337b0-626b-47f2-b3b3-35b5d8e5529a)

Now all the E2E tests are finally green again.
