### PR TITLE
Update PyTorch/XLA to 20250606

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250501"
+torch_xla_version = "20250606"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250601"
+torch_xla_version = "20250531"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250531"
+torch_xla_version = "20250606"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250528"
+torch_xla_version = "20250530"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250530"
+torch_xla_version = "20250602"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250602"
+torch_xla_version = "20250601"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250606"
+torch_xla_version = "20250528"
 
 [tool.setuptools.packages.find]
 where = [""]

--- a/torchprime/launcher/thunk.py
+++ b/torchprime/launcher/thunk.py
@@ -17,8 +17,9 @@ xla_flags = f"{xla_flags} --megascale_grpc_enable_xor_tracer=false"
 
 # Workaround for MegaScale perf regression
 #
-# TODO(b/423386767): Remove the `--megascale_grpc_num_channels` override
-# when the perf regression is fixed.
+# TODO(https://github.com/AI-Hypercomputer/torchprime/issues/300):
+# Remove the `--megascale_grpc_num_channels` override when the perf
+# regression is fixed.
 xla_flags = f"{xla_flags} --megascale_grpc_num_channels=64"
 os.environ["LIBTPU_INIT_ARGS"] = xla_flags
 

--- a/torchprime/launcher/thunk.py
+++ b/torchprime/launcher/thunk.py
@@ -14,6 +14,10 @@ from torchprime.launcher import upload_metrics_to_bq
 # `--megascale_grpc_enable_xor_tracer=false` flag when libtpu is updated
 xla_flags = os.environ.get("LIBTPU_INIT_ARGS", "")
 xla_flags = f"{xla_flags} --megascale_grpc_enable_xor_tracer=false"
+
+# Workaround for MegaScale perf regression
+# TODO(b/NNN): Remove the `--megascale_grpc_num_channels` override
+xla_flags = f"{xla_flags} --megascale_grpc_num_channels=64"
 os.environ["LIBTPU_INIT_ARGS"] = xla_flags
 
 # Get the artifact dir from env var.

--- a/torchprime/launcher/thunk.py
+++ b/torchprime/launcher/thunk.py
@@ -16,7 +16,9 @@ xla_flags = os.environ.get("LIBTPU_INIT_ARGS", "")
 xla_flags = f"{xla_flags} --megascale_grpc_enable_xor_tracer=false"
 
 # Workaround for MegaScale perf regression
-# TODO(b/NNN): Remove the `--megascale_grpc_num_channels` override
+#
+# TODO(b/423386767): Remove the `--megascale_grpc_num_channels` override
+# when the perf regression is fixed.
 xla_flags = f"{xla_flags} --megascale_grpc_num_channels=64"
 os.environ["LIBTPU_INIT_ARGS"] = xla_flags
 


### PR DESCRIPTION
Update PyTorch/XLA pin to Jun 6.

Initially this fails the multi-slice E2E test. I had to bisect the problem down to a specific libtpu version (https://github.com/AI-Hypercomputer/torchprime/pull/295) and found the bug in a libtpu commit and a workaround.

This PR adds a workaround for https://github.com/AI-Hypercomputer/torchprime/issues/300