### PR TITLE
Add `xp.Trace` profile scopes to all `nn.Linear` layers

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -121,7 +121,7 @@ jobs:
             task.global_batch_size=8 \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
-            profile_step=3 
+            profile_step=3
 
       - name: Run Llama 3.0 8B (2D sharding)
         id: run-llama-3-8b-2d
@@ -143,7 +143,7 @@ jobs:
             task.max_steps=15 \
             ici_mesh.fsdp=2 \
             ici_mesh.tensor=2 \
-            profile_step=3 
+            profile_step=3
 
       - name: Run Mixtral 8x7B
         id: run-mixtral-8x7b

--- a/torchprime/torch_xla_models/model/base_causal_lm.py
+++ b/torchprime/torch_xla_models/model/base_causal_lm.py
@@ -11,7 +11,7 @@ import os
 import torch
 import torch.nn as nn
 from huggingface_hub import snapshot_download
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 from safetensors import safe_open
 from safetensors.torch import load_file, save_file
 
@@ -92,6 +92,8 @@ class BaseCausalLM(nn.Module):
   Subclasses should implement the `forward` method.
   """
 
+  config: DictConfig
+
   def _init_weights(self, module: nn.Module):
     """Initialize weights for Linear and Embedding layers.
 
@@ -123,7 +125,7 @@ class BaseCausalLM(nn.Module):
     Args:
         input_ids: Input token IDs of shape (batch_size, sequence_length).
         labels (optional): Target labels for computing the loss.
-        attention_mask (toptional): Attention mask to avoid performing attention on padding token indices.
+        attention_mask (optional): Attention mask to avoid performing attention on padding token indices.
 
     Returns:
         tuple: A tuple containing the model's output logits and, optionally, the loss.

--- a/torchprime/torch_xla_models/model/model_utils.py
+++ b/torchprime/torch_xla_models/model/model_utils.py
@@ -12,6 +12,7 @@ def initialize_model_class(model_config):
   """Import and initialize model_class specified by the config."""
   full_model_class_string = model_config.model_class
   module_name, model_class_name = full_model_class_string.rsplit(".", 1)
+  module = None
 
   for candidate_module_name in [f"model.{module_name}", module_name]:
     # use full import path to avoid issues with relative imports

--- a/torchprime/torch_xla_models/model_rewriting/auto_trace.py
+++ b/torchprime/torch_xla_models/model_rewriting/auto_trace.py
@@ -1,0 +1,47 @@
+import functools
+from collections.abc import Callable, Iterator
+from typing import TypeVar
+
+import torch.nn as nn
+import torch_xla.debug.profiler as xp
+
+T = TypeVar("T", bound=nn.Module)
+
+
+def auto_trace(
+  module: T,
+  traced_types: tuple[type, ...] = (nn.Linear,),
+) -> T:
+  """Change the forward pass of the module tree to automatically call `xp.Trace`.
+
+  module: the module tree to add tracing.
+  traced_types: module types to trace. By default, `nn.Linear` layers will be
+    patched to call `xp.Trace` with their member name as the argument.
+  """
+  for name, child in module.named_children():
+    if isinstance(child, traced_types):
+      original_forward = child.forward
+      _patch_module_forward(child, original_forward, name)
+    elif isinstance(child, nn.Module) and _not_empty(child.children()):
+      original_forward = child.forward
+      _patch_module_forward(child, original_forward, name)
+      auto_trace(child, traced_types)
+
+  return module
+
+
+def _not_empty(it: Iterator) -> bool:
+  try:
+    next(it)
+    return True
+  except StopIteration:
+    return False
+
+
+def _patch_module_forward(value: nn.Module, original_forward: Callable, name: str):
+  @functools.wraps(original_forward)
+  def traced_forward(module_self, *args, **kwargs):
+    with xp.Trace(name):
+      return original_forward(*args, **kwargs)
+
+  value.forward = traced_forward.__get__(value, type(value))  # type: ignore

--- a/torchprime/torch_xla_models/model_rewriting/auto_trace.py
+++ b/torchprime/torch_xla_models/model_rewriting/auto_trace.py
@@ -1,5 +1,5 @@
 import functools
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from typing import TypeVar
 
 import torch.nn as nn
@@ -12,7 +12,7 @@ def auto_trace(
   module: T,
   traced_types: tuple[type, ...] = (nn.Linear,),
 ) -> T:
-  """Change the forward pass of the module tree to automatically call `xp.Trace`.
+  """Insert `xp.Trace` in the forward pass of the module tree.
 
   module: the module tree to add tracing.
   traced_types: module types to trace. By default, `nn.Linear` layers will be
@@ -22,21 +22,10 @@ def auto_trace(
     if isinstance(child, traced_types):
       original_forward = child.forward
       _patch_module_forward(child, original_forward, name)
-    elif isinstance(child, nn.Module) and _not_empty(child.children()):
-      original_forward = child.forward
-      if not isinstance(child, nn.ModuleList) and not isinstance(child, nn.Sequential):
-        _patch_module_forward(child, original_forward, name)
+    elif isinstance(child, nn.Module):
       auto_trace(child, traced_types)
 
   return module
-
-
-def _not_empty(it: Iterator) -> bool:
-  try:
-    next(it)
-    return True
-  except StopIteration:
-    return False
 
 
 def _patch_module_forward(value: nn.Module, original_forward: Callable, name: str):

--- a/torchprime/torch_xla_models/model_rewriting/auto_trace.py
+++ b/torchprime/torch_xla_models/model_rewriting/auto_trace.py
@@ -1,5 +1,4 @@
-import functools
-from collections.abc import Callable
+from types import MethodType
 from typing import TypeVar
 
 import torch.nn as nn
@@ -20,18 +19,17 @@ def auto_trace(
   """
   for name, child in module.named_children():
     if isinstance(child, traced_types):
-      original_forward = child.forward
-      _patch_module_forward(child, original_forward, name)
+      _patch_module_forward(child, name)
     elif isinstance(child, nn.Module):
       auto_trace(child, traced_types)
 
   return module
 
 
-def _patch_module_forward(value: nn.Module, original_forward: Callable, name: str):
-  @functools.wraps(original_forward)
+def _patch_module_forward(module: nn.Module, name: str):
   def traced_forward(module_self, *args, **kwargs):
     with xp.Trace(name):
-      return original_forward(*args, **kwargs)
+      return module_self._auto_trace_forward_original(*args, **kwargs)  # type: ignore
 
-  value.forward = traced_forward.__get__(value, type(value))  # type: ignore
+  module._auto_trace_forward_original = module.forward  # type: ignore
+  module.forward = MethodType(traced_forward, module)

--- a/torchprime/torch_xla_models/model_rewriting/auto_trace.py
+++ b/torchprime/torch_xla_models/model_rewriting/auto_trace.py
@@ -24,7 +24,8 @@ def auto_trace(
       _patch_module_forward(child, original_forward, name)
     elif isinstance(child, nn.Module) and _not_empty(child.children()):
       original_forward = child.forward
-      _patch_module_forward(child, original_forward, name)
+      if not isinstance(child, nn.ModuleList) and not isinstance(child, nn.Sequential):
+        _patch_module_forward(child, original_forward, name)
       auto_trace(child, traced_types)
 
   return module

--- a/torchprime/torch_xla_models/tests/test_auto_trace.py
+++ b/torchprime/torch_xla_models/tests/test_auto_trace.py
@@ -1,0 +1,173 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from torchprime.torch_xla_models.model_rewriting.auto_trace import auto_trace
+
+
+class TestAutoTrace:
+  @pytest.fixture
+  def mock_trace(self, monkeypatch):
+    """Mock xp.Trace with a context manager that records calls"""
+    trace_calls = []
+
+    # Create a class that acts as both callable and context manager
+    class MockTrace:
+      calls: list[str]
+
+      def __init__(self, name):
+        self.name = name
+        trace_calls.append(name)
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, *args):
+        pass
+
+    MockTrace.calls = trace_calls
+    monkeypatch.setattr("torch_xla.debug.profiler.Trace", MockTrace)
+    return MockTrace
+
+  def test_linear_layers_are_traced(self, mock_trace):
+    """Test that Linear layers get traced with their attribute names"""
+
+    class Model(nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(10, 20)
+        self.fc2 = nn.Linear(20, 30)
+        self.relu = nn.ReLU()  # Should not be traced
+
+      def forward(self, x):
+        x = self.fc1(x)
+        x = self.relu(x)
+        x = self.fc2(x)
+        return x
+
+    # Clear any setup calls
+    mock_trace.calls.clear()
+
+    # Create model and run forward
+    model = auto_trace(Model())
+    x = torch.randn(5, 10)
+    output = model(x)
+
+    # Verify traces were created with correct names
+    assert "fc1" in mock_trace.calls
+    assert "fc2" in mock_trace.calls
+    assert len(mock_trace.calls) == 2
+
+    # Verify output shape is correct
+    assert output.shape == (5, 30)
+
+  def test_custom_traced_types(self, mock_trace):
+    """Test tracing custom module types"""
+
+    class CustomLayer(nn.Module):
+      def forward(self, x):
+        return x * 2
+
+    class Model(nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.custom = CustomLayer()
+        self.linear = nn.Linear(10, 10)  # Should not be traced
+
+      def forward(self, x):
+        x = self.custom(x)
+        x = self.linear(x)
+        return x
+
+    mock_trace.calls.clear()
+
+    model = auto_trace(Model(), traced_types=(CustomLayer,))
+    x = torch.randn(5, 10)
+    _ = model(x)
+
+    # Only custom layer should be traced
+    assert "custom" in mock_trace.calls
+    assert "linear" not in mock_trace.calls
+
+  def test_multiple_forward_calls(self, mock_trace):
+    """Test that traces are created on each forward call"""
+
+    class Model(nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(10, 10)
+
+      def forward(self, x):
+        return self.fc(x)
+
+    mock_trace.calls.clear()
+
+    model = auto_trace(Model())
+    x = torch.randn(5, 10)
+
+    # Call forward multiple times
+    for _ in range(3):
+      model(x)
+
+    # Should have 3 traces
+    assert mock_trace.calls.count("fc") == 3
+
+  def test_nested_modules_recursive(self, mock_trace):
+    """Test tracing in nested module structures"""
+
+    class SubModule(nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 10)
+
+      def forward(self, x):
+        return self.linear(x)
+
+    class Model(nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.sub = SubModule()
+        self.fc = nn.Linear(10, 10)
+
+      def forward(self, x):
+        x = self.sub(x)
+        x = self.fc(x)
+        return x
+
+    mock_trace.calls.clear()
+
+    model = Model()
+    model = auto_trace(model)
+    x = torch.randn(5, 10)
+    _ = model(x)
+
+    assert "fc" in mock_trace.calls
+    assert "sub" in mock_trace.calls
+    assert "linear" in mock_trace.calls
+    assert len(mock_trace.calls) == 3
+
+  def test_original_functionality_preserved(self, mock_trace):
+    """Test that the original forward functionality is preserved"""
+
+    # Create two identical models, one with decorator
+    class MyModel(nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(10, 20)
+
+      def forward(self, x):
+        return self.fc(x) * 2
+
+    # Set same weights
+    traced = auto_trace(MyModel())
+    untraced = MyModel()
+    untraced.fc.weight.data = traced.fc.weight.data.clone()
+    untraced.fc.bias.data = traced.fc.bias.data.clone()
+
+    x = torch.randn(5, 10)
+
+    # Outputs should be identical
+    traced_out = traced(x)
+    untraced_out = untraced(x)
+
+    torch.testing.assert_close(traced_out, untraced_out)

--- a/torchprime/torch_xla_models/tests/test_auto_trace.py
+++ b/torchprime/torch_xla_models/tests/test_auto_trace.py
@@ -142,9 +142,9 @@ class TestAutoTrace:
     _ = model(x)
 
     assert "fc" in mock_trace.calls
-    assert "sub" in mock_trace.calls
+    assert "sub" not in mock_trace.calls  # Only `Linear` layer should be traced
     assert "linear" in mock_trace.calls
-    assert len(mock_trace.calls) == 3
+    assert len(mock_trace.calls) == 2
 
   def test_original_functionality_preserved(self, mock_trace):
     """Test that the original forward functionality is preserved"""

--- a/torchprime/torch_xla_models/train.py
+++ b/torchprime/torch_xla_models/train.py
@@ -33,10 +33,10 @@ assert xr.is_spmd() is True
 
 @hydra.main(version_base=None, config_path="configs", config_name="default")
 def main(config: DictConfig):
-  metrics_logger = (
-    MetricsLogger()
-  )  # Call metricslogger in the beginning to get correct start time.
-  print(OmegaConf.to_yaml(config))  # Print the config for debugging
+  # Call metrics logger in the beginning to get the correct start time.
+  metrics_logger = MetricsLogger()
+  # Print the config for debugging
+  print(OmegaConf.to_yaml(config))
   log_level = logging.INFO
   logger.setLevel(log_level)
   logger.setLevel(log_level)

--- a/torchprime/torch_xla_models/trainer/base_trainer.py
+++ b/torchprime/torch_xla_models/trainer/base_trainer.py
@@ -91,7 +91,7 @@ class Trainer:
     # Without this patch, an `nn.Linear` module will flatten non-contracting dimensions
     # (e.g. batch and sequence), thus destroying the sharding constraints on those dimensions.
     model = apply_xla_patch_to_nn_linear(model)
-    # Add `xp.Trace` to the forward pass of the module tree.
+    # Add `xp.Trace` to linear layers in the module tree.
     model = auto_trace(model)
     # Setup SPMD mesh and shard the model.
     model, self.input_sharding_spec, self.minibatch = setup_sharding_and_mesh(

--- a/torchprime/torch_xla_models/trainer/base_trainer.py
+++ b/torchprime/torch_xla_models/trainer/base_trainer.py
@@ -28,6 +28,7 @@ from omegaconf import DictConfig, OmegaConf
 from torch import nn
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 from torch.utils.tensorboard import SummaryWriter
+from torch_xla.distributed.spmd.xla_sharding import apply_xla_patch_to_nn_linear
 from transformers import (
   default_data_collator,
   get_scheduler,
@@ -85,8 +86,14 @@ class Trainer:
     # Initialize tensorboard metrics writer
     self._initialize_tensorboard_writer()
 
-    # Model transformations
+    # -- Model transformations --
+    # Recursively replace `nn.Linear` layers with einsum operations in the model.
+    # Without this patch, an `nn.Linear` module will flatten non-contracting dimensions
+    # (e.g. batch and sequence), thus destroying the sharding constraints on those dimensions.
+    model = apply_xla_patch_to_nn_linear(model)
+    # Add `xp.Trace` to the forward pass of the module tree.
     model = auto_trace(model)
+    # Setup SPMD mesh and shard the model.
     model, self.input_sharding_spec, self.minibatch = setup_sharding_and_mesh(
       model, config
     )

--- a/torchprime/torch_xla_models/trainer/base_trainer.py
+++ b/torchprime/torch_xla_models/trainer/base_trainer.py
@@ -36,6 +36,7 @@ from transformers.optimization import Adafactor
 
 from torchprime.metrics.mfu import compute_mfu
 from torchprime.metrics.step_duration import step_duration_from_latest_profile
+from torchprime.torch_xla_models.model_rewriting.auto_trace import auto_trace
 from torchprime.torch_xla_models.model_rewriting.rematerialization_utils import (
   add_activation_checkpointing_and_scan,
   add_optimization_barriers,
@@ -84,12 +85,11 @@ class Trainer:
     # Initialize tensorboard metrics writer
     self._initialize_tensorboard_writer()
 
-    # Sharding setup
+    # Model transformations
+    model = auto_trace(model)
     model, self.input_sharding_spec, self.minibatch = setup_sharding_and_mesh(
       model, config
     )
-
-    # Model transformations
     model = add_activation_checkpointing_and_scan(model, config)
     model = add_optimization_barriers(model, config)
     self.model = model


### PR DESCRIPTION
LLMs use a lot of linear layers and it is nice to disambiguate them on the profile.

Before this PR:

![screenshot-2025-06-08-20-59-59](https://github.com/user-attachments/assets/c87ab7b5-ab20-4125-b8e6-9cee4115ac4f)

After this PR:

![screenshot-2025-06-08-20-49-15](https://github.com/user-attachments/assets/cbbf0204-48d5-4dc1-98d9-b69d44e40166)

Note the presence of `o_proj`, `up_proj`, `down_proj`, `gate_proj`, etc.

Now we'll actually know what a specific einsum is doing.