### PR TITLE
Update profiler defaults

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -79,7 +79,7 @@ jobs:
             task.global_batch_size=8 \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
-            profile_step=3 
+            profile_start_step=3
 
       - name: Run Llama 3.1 8B (Splash Attention)
         id: run-llama-3_1-8b-SplashAttention
@@ -100,7 +100,7 @@ jobs:
             task.global_batch_size=8 \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
-            profile_step=3 
+            profile_start_step=3
 
       - name: Run Llama 3.1 8B (Scan + Offload)
         id: run-llama-3_1-8b-scan-offload
@@ -121,7 +121,7 @@ jobs:
             task.global_batch_size=8 \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
-            profile_step=3
+            profile_start_step=3
 
       - name: Run Llama 3.0 8B (2D sharding)
         id: run-llama-3-8b-2d
@@ -143,7 +143,7 @@ jobs:
             task.max_steps=15 \
             ici_mesh.fsdp=2 \
             ici_mesh.tensor=2 \
-            profile_step=3
+            profile_start_step=3
 
       - name: Run Mixtral 8x7B
         id: run-mixtral-8x7b
@@ -164,7 +164,7 @@ jobs:
             task.global_batch_size=8 \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
-            profile_step=3 
+            profile_start_step=3
 
       - name: Run Llama 3.0 8B (2 slice)
         id: run-llama-3-8b-2-slice
@@ -187,7 +187,7 @@ jobs:
             task.max_steps=15 \
             dcn_mesh.fsdp=2 \
             ici_mesh.fsdp=4 \
-            profile_step=3 
+            profile_start_step=3
 
   # Load reference step times
   load-benchmarks:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -77,7 +77,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=20 \
+            task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -98,7 +98,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=20 \
+            task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -119,7 +119,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=20 \
+            task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -140,7 +140,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=20 \
+            task.max_steps=15 \
             ici_mesh.fsdp=2 \
             ici_mesh.tensor=2 \
             profile_start_step=3
@@ -162,7 +162,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=20 \
+            task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -184,7 +184,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=16 \
-            task.max_steps=20 \
+            task.max_steps=15 \
             dcn_mesh.fsdp=2 \
             ici_mesh.fsdp=4 \
             profile_start_step=3

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -77,7 +77,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=15 \
+            task.max_steps=20 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -98,7 +98,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=15 \
+            task.max_steps=20 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -119,7 +119,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=15 \
+            task.max_steps=20 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -140,7 +140,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=15 \
+            task.max_steps=20 \
             ici_mesh.fsdp=2 \
             ici_mesh.tensor=2 \
             profile_start_step=3
@@ -162,7 +162,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
-            task.max_steps=15 \
+            task.max_steps=20 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
 
@@ -184,7 +184,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=16 \
-            task.max_steps=15 \
+            task.max_steps=20 \
             dcn_mesh.fsdp=2 \
             ici_mesh.fsdp=4 \
             profile_start_step=3

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,8 +19,9 @@ compute the time delta between the start of every training step on the
 accelerator, and the median value of those time delta will be used as the
 `step_execution_time`.
 
-To obtain the step execution time, set a non-negative value in the `profile_step`
-CLI argument to the trainer. Typically, you should use `profile_step` of at least
+To obtain the step execution time, set a non-negative value in the
+`profile_start_step` CLI argument to the trainer. Typically, you should use
+`profile_start_step` of at least
 2 to skip over the first two compilation steps, which introduces large idle gaps
 on the accelerator.
 

--- a/torchprime/tests/test_profiling_utils.py
+++ b/torchprime/tests/test_profiling_utils.py
@@ -10,4 +10,3 @@ def test_ensure_profile_end_step_sets_default():
   cfg = OmegaConf.create({"profile_start_step": 5, "profile_end_step": None})
   ensure_profile_end_step(cfg)
   assert cfg.profile_end_step == 15
-

--- a/torchprime/tests/test_profiling_utils.py
+++ b/torchprime/tests/test_profiling_utils.py
@@ -7,6 +7,38 @@ from torchprime.utils.profiling import ensure_profile_end_step
 
 def test_ensure_profile_end_step_sets_default():
   """ensure_profile_end_step sets profile_end_step when missing."""
-  cfg = OmegaConf.create({"profile_start_step": 5, "profile_end_step": None})
+  cfg = OmegaConf.create(
+    {"profile_start_step": 5, "profile_end_step": None, "task": {"max_steps": 40}}
+  )
   ensure_profile_end_step(cfg)
   assert cfg.profile_end_step == 15
+
+  cfg = OmegaConf.create(
+    {"profile_start_step": 5, "profile_end_step": None, "task": {"max_steps": 15}}
+  )
+  ensure_profile_end_step(cfg)
+  assert cfg.profile_end_step == 10
+
+  cfg = OmegaConf.create(
+    {"profile_start_step": -1, "profile_end_step": None, "task": {"max_steps": 15}}
+  )
+  ensure_profile_end_step(cfg)
+  assert cfg.profile_end_step == -1
+
+  cfg = OmegaConf.create(
+    {"profile_start_step": 5, "profile_end_step": 100, "task": {"max_steps": 15}}
+  )
+  ensure_profile_end_step(cfg)
+  assert cfg.profile_end_step == 10
+
+  cfg = OmegaConf.create(
+    {"profile_start_step": 5, "profile_end_step": 20, "task": {"max_steps": 100}}
+  )
+  ensure_profile_end_step(cfg)
+  assert cfg.profile_end_step == 20
+
+  cfg = OmegaConf.create(
+    {"profile_start_step": 5, "profile_end_step": None, "task": {"max_steps": 15}}
+  )
+  ensure_profile_end_step(cfg, num_profile_steps=3)
+  assert cfg.profile_end_step == 8

--- a/torchprime/tests/test_profiling_utils.py
+++ b/torchprime/tests/test_profiling_utils.py
@@ -1,0 +1,13 @@
+"""Tests for profiling utility functions."""
+
+from omegaconf import OmegaConf
+
+from torchprime.utils.profiling import ensure_profile_end_step
+
+
+def test_ensure_profile_end_step_sets_default():
+  """ensure_profile_end_step sets profile_end_step when missing."""
+  cfg = OmegaConf.create({"profile_start_step": 5, "profile_end_step": None})
+  ensure_profile_end_step(cfg)
+  assert cfg.profile_end_step == 15
+

--- a/torchprime/tests/test_profiling_utils.py
+++ b/torchprime/tests/test_profiling_utils.py
@@ -11,7 +11,7 @@ def test_ensure_profile_end_step_sets_default():
     {"profile_start_step": 5, "profile_end_step": None, "task": {"max_steps": 40}}
   )
   ensure_profile_end_step(cfg)
-  assert cfg.profile_end_step == 15
+  assert cfg.profile_end_step == 25
 
   cfg = OmegaConf.create(
     {"profile_start_step": 5, "profile_end_step": None, "task": {"max_steps": 15}}
@@ -42,3 +42,9 @@ def test_ensure_profile_end_step_sets_default():
   )
   ensure_profile_end_step(cfg, num_profile_steps=3)
   assert cfg.profile_end_step == 8
+
+  cfg = OmegaConf.create(
+    {"profile_start_step": 5, "profile_end_step": 10, "task": {"max_steps": 8}}
+  )
+  ensure_profile_end_step(cfg)
+  assert cfg.profile_end_step == 6

--- a/torchprime/torch_xla_models/README.md
+++ b/torchprime/torch_xla_models/README.md
@@ -52,8 +52,6 @@ tp run torchprime/torch_xla_models/train.py \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
     profile_start_step=6 \
-    profile_end_step=16 \
-    profile_duration=20000 \
     ici_mesh.fsdp=256 \
     model/remat=llama-scan \
     model.attention_kernel=splash_attention
@@ -73,8 +71,6 @@ tp run torchprime/torch_xla_models/train.py \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
     profile_start_step=6 \
-    profile_end_step=16 \
-    profile_duration=20000 \
     ici_mesh.fsdp=256 \
     model/remat=llama-scan \
     model.attention_kernel=splash_attention
@@ -94,8 +90,6 @@ tp run torchprime/torch_xla_models/train.py \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
     profile_start_step=5 \
-    profile_end_step=15 \
-    profile_duration=250000  \
     ici_mesh.fsdp=256 \
     model/remat=llama-scan-offload \
     model.attention_kernel=splash_attention
@@ -121,8 +115,6 @@ tp run torchprime/torch_xla_models/train.py \
     ici_mesh.fsdp=64 \
     ici_mesh.tensor=4 \
     profile_start_step=5 \
-    profile_end_step=15 \
-    profile_duration=240000 \
     logging_steps=10
 ```
 
@@ -146,8 +138,6 @@ tp run torchprime/torch_xla_models/train.py \
     ici_mesh.fsdp=64 \
     ici_mesh.tensor=4 \
     profile_start_step=15 \
-    profile_end_step=25 \
-    profile_duration=240000 \
     logging_steps=10
 ```
 

--- a/torchprime/torch_xla_models/README.md
+++ b/torchprime/torch_xla_models/README.md
@@ -51,7 +51,8 @@ tp run torchprime/torch_xla_models/train.py \
     task.global_batch_size=1024 \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
-    profile_step=6 \
+    profile_start_step=6 \
+    profile_end_step=16 \
     profile_duration=20000 \
     ici_mesh.fsdp=256 \
     model/remat=llama-scan \
@@ -71,7 +72,8 @@ tp run torchprime/torch_xla_models/train.py \
     task.global_batch_size=1024 \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
-    profile_step=6 \
+    profile_start_step=6 \
+    profile_end_step=16 \
     profile_duration=20000 \
     ici_mesh.fsdp=256 \
     model/remat=llama-scan \
@@ -91,7 +93,8 @@ tp run torchprime/torch_xla_models/train.py \
     task.global_batch_size=512 \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
-    profile_step=5 \
+    profile_start_step=5 \
+    profile_end_step=15 \
     profile_duration=250000  \
     ici_mesh.fsdp=256 \
     model/remat=llama-scan-offload \
@@ -117,7 +120,8 @@ tp run torchprime/torch_xla_models/train.py \
     dataset.block_size=8192 \
     ici_mesh.fsdp=64 \
     ici_mesh.tensor=4 \
-    profile_step=5 \
+    profile_start_step=5 \
+    profile_end_step=15 \
     profile_duration=240000 \
     logging_steps=10
 ```
@@ -141,7 +145,8 @@ tp run torchprime/torch_xla_models/train.py \
     dcn_mesh.fsdp=2 \
     ici_mesh.fsdp=64 \
     ici_mesh.tensor=4 \
-    profile_step=15 \
+    profile_start_step=15 \
+    profile_end_step=25 \
     profile_duration=240000 \
     logging_steps=10
 ```
@@ -160,7 +165,8 @@ tp run torchprime/torch_xla_models/train.py \
     dataset=wikitext \
     dataset.hf_dataset_config_name=wikitext-103-raw-v1 \
     ici_mesh.fsdp=256 \
-    profile_step=5
+    profile_start_step=5 \
+    profile_end_step=15
 ```
 
 ## Key Components

--- a/torchprime/torch_xla_models/configs/default.yaml
+++ b/torchprime/torch_xla_models/configs/default.yaml
@@ -15,7 +15,7 @@ torch_dtype: bfloat16
 
 # set profile_start_step to a positive integer to enable profiling and start profiling 
 # at that step. If profile_end_step is not set, profiling will continue until for 
-# num_profile_steps (default 10) training steps or total step - 5 (to avoid issue #260)
+# num_profile_steps (default 20) training steps or total step - 5 (to avoid issue #260)
 # Also, try to make number of profile profile steps >= 10
 profile_start_step: 3
 profile_end_step: null

--- a/torchprime/torch_xla_models/configs/default.yaml
+++ b/torchprime/torch_xla_models/configs/default.yaml
@@ -14,7 +14,8 @@ logging_steps: 10
 torch_dtype: bfloat16
 
 # This might be overwritten when using tp run to launch the run using XPK
-profile_step: 2
+profile_start_step: 3
+profile_end_step: null
 profile_dir: profile
 profile_duration: 100000
 

--- a/torchprime/torch_xla_models/configs/default.yaml
+++ b/torchprime/torch_xla_models/configs/default.yaml
@@ -13,11 +13,16 @@ seed: 42
 logging_steps: 10
 torch_dtype: bfloat16
 
-# This might be overwritten when using tp run to launch the run using XPK
+# set profile_start_step to a positive integer to enable profiling and start profiling 
+# at that step. If profile_end_step is not set, profiling will continue until for 
+# num_profile_steps (default 10) training steps or total step - 5 (to avoid issue #260)
+# Also, try to make number of profile profile steps >= 10
 profile_start_step: 3
 profile_end_step: null
+
+# The directory where profiling data will be stored. This might be overwritten 
+# when using tp run to launch the run using XPK
 profile_dir: profile
-profile_duration: 100000
 
 # This might be overwritten when using tp run to launch the run using XPK
 output_dir: outputs

--- a/torchprime/torch_xla_models/tests/test_trainer.py
+++ b/torchprime/torch_xla_models/tests/test_trainer.py
@@ -327,6 +327,10 @@ def test_profiler_trace(monkeypatch, dummy_config):
 
   monkeypatch.setattr(xp, "start_trace", fake_start)
   monkeypatch.setattr(xp, "stop_trace", fake_stop)
+  monkeypatch.setattr(
+    "torchprime.torch_xla_models.trainer.base_trainer.step_duration_from_latest_profile",
+    lambda *_args, **_kwargs: 0.0,
+  )
 
   dummy_config.profile_start_step = 0
   dummy_config.profile_end_step = 1

--- a/torchprime/torch_xla_models/tests/test_trainer.py
+++ b/torchprime/torch_xla_models/tests/test_trainer.py
@@ -334,6 +334,7 @@ def test_profiler_trace(monkeypatch, dummy_config):
 
   dummy_config.profile_start_step = 0
   dummy_config.profile_end_step = 1
+  dummy_config.task.max_steps = 6
 
   device = xm.xla_device()
   model = DummyModel().to(device)
@@ -342,5 +343,7 @@ def test_profiler_trace(monkeypatch, dummy_config):
 
   trainer.train_loop(metrics_logger=MetricsLogger())
 
+  assert dummy_config.profile_start_step == 0
+  assert dummy_config.profile_end_step == 1
   assert calls["start"] == 1
   assert calls["stop"] == 1

--- a/torchprime/torch_xla_models/tests/test_trainer.py
+++ b/torchprime/torch_xla_models/tests/test_trainer.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import torch_xla.debug.profiler as xp
 from omegaconf import OmegaConf
 from torch.utils.data import Dataset
 
@@ -90,7 +91,8 @@ def dummy_config():
       "run_name": None,
       "output_dir": "/tmp/test_output",
       "logging_steps": 1,
-      "profile_step": -1,
+      "profile_start_step": -1,
+      "profile_end_step": -1,
       "profile_dir": "/tmp/profile",
       "profile_duration": 5,
       "ici_mesh": {"data": 1, "fsdp": 1, "tensor": 1},
@@ -300,3 +302,41 @@ def test_trainer_clip_gradients_by_value(monkeypatch, dummy_config):
     # Verify all gradient values are within [-max_grad_value, max_grad_value]
     assert torch.all(model.linear.weight.grad <= dummy_config.task.max_grad_value)
     assert torch.all(model.linear.weight.grad >= -dummy_config.task.max_grad_value)
+
+
+def test_profiler_trace(monkeypatch, dummy_config):
+  """Verify profiler start_trace and stop_trace are invoked at configured steps."""
+  from torchprime.torch_xla_models.model_rewriting import sharding_initialization
+
+  monkeypatch.setattr(
+    sharding_initialization, "get_mesh", lambda *args, **kwargs: FakeMesh()
+  )
+  monkeypatch.setattr(
+    sharding_initialization,
+    "shard_torch_xla_model_from_config",
+    lambda model, *args, **kwargs: model,
+  )
+
+  calls = {"start": 0, "stop": 0}
+
+  def fake_start(dir):
+    calls["start"] += 1
+
+  def fake_stop():
+    calls["stop"] += 1
+
+  monkeypatch.setattr(xp, "start_trace", fake_start)
+  monkeypatch.setattr(xp, "stop_trace", fake_stop)
+
+  dummy_config.profile_start_step = 0
+  dummy_config.profile_end_step = 1
+
+  device = xm.xla_device()
+  model = DummyModel().to(device)
+  dataset = DummyDataset()
+  trainer = Trainer(model, dummy_config, dataset)
+
+  trainer.train_loop(metrics_logger=MetricsLogger())
+
+  assert calls["start"] == 1
+  assert calls["stop"] == 1

--- a/torchprime/torch_xla_models/trainer/base_trainer.py
+++ b/torchprime/torch_xla_models/trainer/base_trainer.py
@@ -46,6 +46,7 @@ from torchprime.torch_xla_models.model_rewriting.sharding_initialization import 
   setup_sharding_and_mesh,
 )
 from torchprime.torch_xla_models.topology import get_num_slices
+from torchprime.utils.profiling import ensure_profile_end_step
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,7 @@ class Trainer:
     train_dataset: Dataset | IterableDataset | None,
   ):
     self.config = config
+    ensure_profile_end_step(self.config)
     self.device = xm.xla_device()
     self.global_batch_size = self.config.task.global_batch_size
     self.train_dataset = train_dataset
@@ -260,22 +262,23 @@ class Trainer:
           run_async=True,
         )
 
-      # Capture profile at the prefer step
-      if step == self.config.profile_step:
-        # Wait until device execution catches up to tracing before triggering the profile. This will
-        # interrupt training slightly on the hosts which are capturing, but by waiting after tracing
-        # for the step, the interruption will be minimal.
+      # Start profiler trace at the configured step
+      if step == self.config.profile_start_step:
+        # Wait until device execution catches up to tracing before triggering the profile.
+        # This will interrupt training slightly on the hosts which are capturing, but by waiting
+        # after tracing for the step, the interruption will be minimal.
         xm.wait_device_ops()
-        xp.trace_detached(
-          "127.0.0.1:9012",
-          self.config.profile_dir,
-          self.config.profile_duration,
-        )
+        xp.start_trace(self.config.profile_dir)
+
+      # Stop profiler trace at the configured step
+      if step == self.config.profile_end_step:
+        xm.wait_device_ops()
+        xp.stop_trace()
 
     xm.wait_device_ops()
     logger.info("Finished training run")
 
-    if self.config.profile_step >= 0:
+    if self.config.profile_end_step >= 0:
       # Analyze the step duration from the latest profile
       step_duration = step_duration_from_latest_profile(self.config.profile_dir)
       metrics_logger.log_step_execution_time(step_duration)

--- a/torchprime/torch_xla_models/trainer/base_trainer.py
+++ b/torchprime/torch_xla_models/trainer/base_trainer.py
@@ -278,7 +278,7 @@ class Trainer:
     xm.wait_device_ops()
     logger.info("Finished training run")
 
-    if self.config.profile_end_step >= 0:
+    if self.config.profile_start_step >= 0 and self.config.profile_end_step >= 0:
       # Analyze the step duration from the latest profile
       step_duration = step_duration_from_latest_profile(self.config.profile_dir)
       metrics_logger.log_step_execution_time(step_duration)

--- a/torchprime/utils/profiling.py
+++ b/torchprime/utils/profiling.py
@@ -1,0 +1,19 @@
+"""Profiling utilities for trainer configuration."""
+
+from omegaconf import DictConfig
+
+
+def ensure_profile_end_step(config: DictConfig, default_span: int = 10) -> None:
+  """Set ``profile_end_step`` based on ``profile_start_step`` if missing.
+
+  Args:
+    config: Trainer configuration object.
+    default_span: Number of steps to trace when ``profile_end_step`` is ``None``.
+
+  Returns:
+    None. ``config`` is modified in place.
+  """
+  start = getattr(config, "profile_start_step", -1)
+  end = getattr(config, "profile_end_step", None)
+  if start >= 0 and end is None:
+    config.profile_end_step = start + default_span

--- a/torchprime/utils/profiling.py
+++ b/torchprime/utils/profiling.py
@@ -5,7 +5,7 @@ from omegaconf import DictConfig
 
 def ensure_profile_end_step(
   config: DictConfig,
-  num_profile_steps: int = 10,
+  num_profile_steps: int = 20,
 ) -> None:
   """Set ``profile_end_step`` based on ``profile_start_step`` if missing.
 
@@ -18,7 +18,7 @@ def ensure_profile_end_step(
   """
   start = getattr(config, "profile_start_step", -1)
   end = getattr(config, "profile_end_step", None)
-  num_profile_steps = getattr(config, "num_profile_steps", None) or num_profile_steps
+  num_profile_steps = getattr(config, "num_profile_steps", num_profile_steps)
 
   max_steps = config.task.max_steps
   if start < 0 or start >= max_steps:
@@ -30,6 +30,7 @@ def ensure_profile_end_step(
     end = start + num_profile_steps
 
   end = min(end, max_steps - 5)  # to prevent issue #260.
+  end = max(end, start + 1)  # and ensure end is greater than start
 
   config.profile_end_step = end
   return config

--- a/torchprime/utils/profiling.py
+++ b/torchprime/utils/profiling.py
@@ -3,7 +3,7 @@
 from omegaconf import DictConfig
 
 
-def ensure_profile_end_step(config: DictConfig, default_span: int = 10) -> None:
+def ensure_profile_end_step(config: DictConfig, default_span: int = 7) -> None:
   """Set ``profile_end_step`` based on ``profile_start_step`` if missing.
 
   Args:

--- a/torchprime/utils/profiling.py
+++ b/torchprime/utils/profiling.py
@@ -21,7 +21,7 @@ def ensure_profile_end_step(
   num_profile_steps = getattr(config, "num_profile_steps", num_profile_steps)
 
   max_steps = config.task.max_steps
-  if start < 0 or start >= max_steps:
+  if start < 0 or start >= max_steps - 1:  # at lease 2 steps are needed for profiling
     config.profile_start_step = -1
     config.profile_end_step = -1
     return config

--- a/torchprime/utils/profiling.py
+++ b/torchprime/utils/profiling.py
@@ -3,17 +3,33 @@
 from omegaconf import DictConfig
 
 
-def ensure_profile_end_step(config: DictConfig, default_span: int = 7) -> None:
+def ensure_profile_end_step(
+  config: DictConfig,
+  num_profile_steps: int = 10,
+) -> None:
   """Set ``profile_end_step`` based on ``profile_start_step`` if missing.
 
   Args:
     config: Trainer configuration object.
-    default_span: Number of steps to trace when ``profile_end_step`` is ``None``.
+    num_profile_steps: Number of steps to trace when ``profile_end_step`` is ``None``.
 
   Returns:
     None. ``config`` is modified in place.
   """
   start = getattr(config, "profile_start_step", -1)
   end = getattr(config, "profile_end_step", None)
-  if start >= 0 and end is None:
-    config.profile_end_step = start + default_span
+  num_profile_steps = getattr(config, "num_profile_steps", None) or num_profile_steps
+
+  max_steps = config.task.max_steps
+  if start < 0 or start >= max_steps:
+    config.profile_start_step = -1
+    config.profile_end_step = -1
+    return config
+
+  if end is None:
+    end = start + num_profile_steps
+
+  end = min(end, max_steps - 5)  # to prevent issue #260.
+
+  config.profile_end_step = end
+  return config


### PR DESCRIPTION
Fixing https://github.com/AI-Hypercomputer/torchprime/issues/263

## Summary
- update `xp.trace_detached` with `start_trace` and `stop_trace`
- default profile_start_step to 3 and profile_end_step to null
- add utility ensure_profile_end_step to compute default end step
- call utility during trainer initialization
- test ensure_profile_end_step
