### PR TITLE
Fix llama ddp+fsdp timing

### DIFF
--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -43,12 +43,12 @@ benchmarks:
     sample_size: 416
   llama-3-8b-ddp-fsdp:
     name: Llama 3.0 8B (ddp + fsdp)
-    step_time_lower_bound: 3.82985294 # copyed from llama-3-8b-2-slice
-    step_time_upper_bound: 4.087614 # copyed from llama-3-8b-2-slice
-    confidence_interval: 0.12888 # copyed from llama-3-8b-2-slice
-    average: 3.9587 # copyed from llama-3-8b-2-slice
-    sample_size: 416 # copyed from llama-3-8b-2-slice
+    step_time_lower_bound: 3.22420277
+    step_time_upper_bound: 3.351676
+    confidence_interval: 0.06374
+    average: 3.2879
+    sample_size: 47
 metadata:
   query_start: '2025-05-26T18:37:58.674556-07:00'
-  query_end: '2025-06-05T18:37:58-07:00'
+  query_end: '2025-06-13T13:20:09-07:00'
   confidence_level: 0.999

--- a/e2e_testing/update_step_time.py
+++ b/e2e_testing/update_step_time.py
@@ -26,6 +26,7 @@ def match_llama3_8b(row):
   config = json.loads(row.configs_framework)
   return (
     row.run_id.startswith("llama-3-8b-")
+    and config["dcn_mesh"]["data"] == 1
     and config["dcn_mesh"]["fsdp"] == 1
     and config["ici_mesh"]["tensor"] == 1
   )
@@ -79,6 +80,7 @@ def match_llama_3_8b_ddp_fsdp(row):
     row.run_id.startswith("llama-3-8b-ddp-fsdp")
     and config["dcn_mesh"]["data"] == 2
     and config["ici_mesh"]["fsdp"] == 4
+    and config["ici_mesh"]["tensor"] == 1
   )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 tp = "torchprime.launcher.cli:cli"
 
 [tool.torchprime]
-torch_xla_version = "20250606"
+torch_xla_version = "20250612"
 
 [tool.setuptools.packages.find]
 where = [""]


### PR DESCRIPTION
I ran `e2e_testing/update_step_time.py --limit 3000 --start-time '1 days ago'` but preserved the timing for the existing tasks.

The reason I did that instead of using `20 days ago` is because the update_step_time.py script will read timings from all runs, including those that introduced the regressions. Finding a way to filter out the bad runs from the BigQuery database is a future exercise.