### PR TITLE
[e2e_test] Don't change learning rate

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -78,6 +78,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
@@ -99,6 +100,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
@@ -120,6 +122,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
@@ -141,6 +144,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             ici_mesh.fsdp=2 \
             ici_mesh.tensor=2 \
@@ -163,6 +167,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=8 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             ici_mesh.fsdp=4 \
             profile_start_step=3
@@ -185,6 +190,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=16 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             dcn_mesh.fsdp=2 \
             ici_mesh.fsdp=4 \
@@ -208,6 +214,7 @@ jobs:
             dataset=wikitext \
             task=train \
             task.global_batch_size=16 \
+            task.lr_scheduler.type=constant \
             task.max_steps=15 \
             dcn_mesh.data=2 \
             ici_mesh.fsdp=4 \

--- a/torchprime/torch_xla_models/configs/task/train.yaml
+++ b/torchprime/torch_xla_models/configs/task/train.yaml
@@ -1,5 +1,5 @@
 # This is for basic training loop, i.e., forward/backward pass without any special task logic.
-name: train 
+name: train
 global_batch_size: 4
 max_steps: 15
 


### PR DESCRIPTION
This reduces E2E test duration from 24 minutes to 21 minutes. The reason is the recompilation bug in http://shortn/_HJtfQ7rYLm and https://github.com/AI-Hypercomputer/torchprime/pull/315.