### PR TITLE
Add loss check for llama-3-8b-sft workflow

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -258,7 +258,7 @@ jobs:
             torchprime/torch_xla_models/train.py \
             --config-name llama-3-8b-sft-w-gsm8k \
             ici_mesh.fsdp=4 \
-            task.max_steps=20 \
+            task.max_steps=50 \
             task.global_batch_size=16 \
             task.lr_scheduler.type=constant \
             task.convert_to_safetensors=False \ 
@@ -304,7 +304,9 @@ jobs:
             "benchmark": .key,
             "name": .value.name,
             "lower_bound": .value.step_time_lower_bound,
-            "upper_bound": .value.step_time_upper_bound
+            "upper_bound": .value.step_time_upper_bound,
+            "target_loss": .value.target_loss,
+            "loss_tolerance": .value.loss_tolerance
           })' e2e_testing/step_time_bounds.yaml)
           echo "Benchmark matrix JSON: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
@@ -340,4 +342,6 @@ jobs:
       artifact_dir: ${{ needs.tp-run.outputs.artifact-dir }}
       step_time_lower_bound: ${{ matrix.config.lower_bound }}
       step_time_upper_bound: ${{ matrix.config.upper_bound }}
+      target_loss: ${{ matrix.config.target_loss }}
+      loss_tolerance: ${{ matrix.config.loss_tolerance }}
     secrets: inherit

--- a/.github/workflows/reusable_e2e_check.yml
+++ b/.github/workflows/reusable_e2e_check.yml
@@ -19,6 +19,14 @@ on:
         description: "Upper bound for step time (in seconds)"
         required: true
         type: number
+      target_loss:
+        description: "Expected final loss value"
+        required: false
+        type: string
+      loss_tolerance:
+        description: "Allowed deviation from the expected loss"
+        required: false
+        type: string
     secrets:
       GCP_SA_KEY:
         required: true
@@ -101,3 +109,9 @@ jobs:
         run: |
           output_dir="${{ inputs.artifact_dir }}/${{ inputs.jobset_name }}/outputs/0-0"
           e2e_testing/check_step_time.py "$output_dir" "${{ inputs.step_time_lower_bound }}" "${{ inputs.step_time_upper_bound }}"
+      - name: Validate loss
+        if: ${{ inputs.target_loss }}
+        run: |
+          e2e_testing/check_loss.py \
+            /tmp/pod-${{ steps.get_pod_name.outputs.pod_name }}.log \
+            "${{ inputs.target_loss }}" "${{ inputs.loss_tolerance }}"

--- a/e2e_testing/check_loss.py
+++ b/e2e_testing/check_loss.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Utility to validate the final loss reported during training."""
+
+import re
+import sys
+
+LOSS_PATTERN = re.compile(r"loss:\s*([0-9]+\.?[0-9]*)")
+
+
+def check_loss(file_path: str, target_loss: float, tolerance: float) -> int:
+  """Check that the loss in ``file_path`` is within ``tolerance`` of ``target_loss``.
+
+  Args:
+    file_path: Path to the log file to parse.
+    target_loss: Expected final loss value.
+    tolerance: Allowed deviation from ``target_loss``.
+
+  Returns:
+    ``0`` if the check passes, ``1`` otherwise.
+  """
+
+  try:
+    with open(file_path) as f:
+      log_data = f.read()
+  except Exception as e:  # pylint: disable=broad-except
+    print(f"Error reading log file {file_path}: {e}")
+    return 1
+
+  matches = LOSS_PATTERN.findall(log_data)
+  if not matches:
+    print("Error: No loss value found in logs")
+    return 1
+
+  last_loss = float(matches[-1])
+  print(f"Last loss found: {last_loss}")
+
+  if abs(last_loss - target_loss) > tolerance:
+    print(
+      f"Error: loss {last_loss:.4f} not within ±{tolerance} of target {target_loss:.4f}"
+    )
+    return 1
+
+  print("Loss check passed.")
+  return 0
+
+
+if __name__ == "__main__":
+  if len(sys.argv) != 4:
+    print("Usage: check_loss.py <log_file> <target_loss> <tolerance>")
+    sys.exit(1)
+
+  sys.exit(check_loss(sys.argv[1], float(sys.argv[2]), float(sys.argv[3])))

--- a/e2e_testing/step_time_bounds.yaml
+++ b/e2e_testing/step_time_bounds.yaml
@@ -57,6 +57,8 @@ benchmarks:
     confidence_interval: 0.5 # some random number
     average: 0.5 # some random number
     sample_size: 123 # some random number
+    target_loss: 0.6
+    loss_tolerance: 0.2
   llama-3-8b-ddp-fsdp:
     name: Llama 3.0 8B (ddp + fsdp)
     step_time_lower_bound: 3.22420277


### PR DESCRIPTION
## Summary
- introduce `check_loss.py` for validating final loss from logs
- extend reusable_e2e_check workflow to support optional loss validation
- propagate new fields through e2e_test.yml
- document target loss and tolerance in step_time_bounds
- run SFT benchmark for 50 steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchprime')*

------
https://chatgpt.com/codex/tasks/task_e_6864018ce7f0832c8ff76d973a1f2692