### PR TITLE
adding expert parallelism to Llama4

### DIFF
--- a/torchprime/torch_xla_models/configs/model/llama-4-text-only-scout-17b-16e.yaml
+++ b/torchprime/torch_xla_models/configs/model/llama-4-text-only-scout-17b-16e.yaml
@@ -1,44 +1,46 @@
-# Modelled by a scalled down version of
+# Modelled by
 # https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E/blob/main/config.json
 defaults:
   - _self_  # refers to this config file
-  - sharding: llama4-fsdp  # refers to sharding/llama4-fsdp.yaml
+  - sharding: llama4-fsdp-tp  # refers to sharding/llama4-fsdp-tp.yaml
   - remat: llama4  # refers to remat/llama4.yaml
 
-model_id: llama-4-text-only-dummy
 model_class: llama4.Llama4TextForCausalLM  # Used to import the model from this class
 tokenizer_name: meta-llama/Llama-4-Scout-17B-16E
+torch_dtype: bfloat16
 use_bfloat16: true
 temperature: 1.0
 bos_token_id: 200000
-pad_token_id: 127
+pad_token_id: 200018
 eos_token_id:
 - 200001
 - 200007
 - 200008
 attention_bias: false
 model_type: llama4_text
+attn_temperature_tuning: 4  # not sure if needed
 attn_scale: 0.1
 floor_scale: 8192
-vocab_size: 1280
+vocab_size: 202048
 max_position_embeddings: 262144
-hidden_size: 512
-intermediate_size: 64
+hidden_size: 5120
+intermediate_size: 8192
 intermediate_size_mlp: 16384
-num_hidden_layers: 2
-num_attention_heads: 8
+num_hidden_layers: 48
+num_attention_heads: 40
 rope_scaling:
   factor: 16.0
   high_freq_factor: 1.0
   low_freq_factor: 1.0
+cache_implementation: hybrid # not sure if needed
 num_key_value_heads: 8
 hidden_act: silu
 initializer_range: 0.02
 rms_norm_eps: 1.0e-05
+use_cache: true      # not sure if needed
 rope_theta: 500000.0
-attn_temperature_tuning: true
 attention_dropout: 0.0
-head_dim: 64
+head_dim: 128
 use_qk_norm: true
 num_experts_per_tok: 1
 num_local_experts: 16
@@ -48,10 +50,101 @@ router_jitter_noise: 0.0
 no_rope_layers:
 - 1
 - 1
-interleave_moe_layer_step: 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
+- 1
+- 1
+- 1
+- 0
 moe_layers:
 - 0
 - 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+- 8
+- 9
+- 10
+- 11
+- 12
+- 13
+- 14
+- 15
+- 16
+- 17
+- 18
+- 19
+- 20
+- 21
+- 22
+- 23
+- 24
+- 25
+- 26
+- 27
+- 28
+- 29
+- 30
+- 31
+- 32
+- 33
+- 34
+- 35
+- 36
+- 37
+- 38
+- 39
+- 40
+- 41
+- 42
+- 43
+- 44
+- 45
+- 46
+- 47
 attention_chunk_size: 8192
-attention_kernel: null
-moe_implementation: sequential
+attention_kernel: flash_attention
+moe_implementation: expert_parallelism

--- a/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp-tp-ep.yaml
+++ b/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp-tp-ep.yaml
@@ -1,0 +1,40 @@
+# Expert parallelism sharding configuration for Llama4 models.
+
+# Weights
+
+# vocab_size, hidden_size
+model.embed_tokens.weight: [fsdp, tensor]
+# hidden_size, num_attention_heads * head_dim
+model.layers.*.self_attn.q_proj.weight: [tensor, fsdp]
+# hidden_size, num_key_value_heads * head_dim
+model.layers.*.self_attn.k_proj.weight: [tensor, fsdp]
+# hidden_size, num_key_value_heads * head_dim
+model.layers.*.self_attn.v_proj.weight: [tensor, fsdp]
+# hidden_size, hidden_size
+model.layers.*.self_attn.o_proj.weight: [fsdp, tensor]
+
+# num_experts, hidden_size, 2 * intermediate_size
+model.layers.*.feed_forward.experts.gate_up_proj: [expert, tensor, fsdp]  
+# num_experts, expert_dim, hidden_size
+model.layers.*.feed_forward.experts.down_proj:  [expert, fsdp, tensor]
+# hidden_size, num_experts
+model.layers.*.feed_forward.router.weight: [fsdp, null]
+# hidden_size, intermediate_size    
+model.layers.*.feed_forward.shared_expert.gate_proj.weight: [tensor, fsdp]
+# hidden_size, intermediate_size    
+model.layers.*.feed_forward.shared_expert.up_proj.weight: [tensor, fsdp]
+# intermediate_size, hidden_size
+model.layers.*.feed_forward.shared_expert.down_proj.weight: [fsdp, tensor]
+# hidden_size
+model.layers.*.input_layernorm.weight: [fsdp]
+# hidden_size
+model.layers.*.post_attention_layernorm.weight: [fsdp]
+# hidden_size
+model.norm.weight: [fsdp]
+# hidden_size, vocab_size
+lm_head.weight: [tensor, fsdp]
+
+# Activations
+# TODO: update for tensor
+model.layers.*: [[data, fsdp], null, tensor]
+lm_head: [[data, fsdp], null, tensor]

--- a/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp-tp.yaml
+++ b/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp-tp.yaml
@@ -1,0 +1,40 @@
+# 2D (FSDP + TP) sharding configuration for Llama4 models.
+
+# Weights
+
+# vocab_size, hidden_size
+model.embed_tokens.weight: [fsdp, tensor]
+# hidden_size, num_attention_heads * head_dim
+model.layers.*.self_attn.q_proj.weight: [tensor, fsdp]
+# hidden_size, num_key_value_heads * head_dim
+model.layers.*.self_attn.k_proj.weight: [tensor, fsdp]
+# hidden_size, num_key_value_heads * head_dim
+model.layers.*.self_attn.v_proj.weight: [tensor, fsdp]
+# hidden_size, hidden_size
+model.layers.*.self_attn.o_proj.weight: [fsdp, tensor]
+
+# num_experts, hidden_size, 2 * intermediate_size
+model.layers.*.feed_forward.experts.gate_up_proj: [null, tensor, fsdp]  
+# num_experts, expert_dim, hidden_size
+model.layers.*.feed_forward.experts.down_proj:  [null, fsdp, tensor]
+# hidden_size, num_experts
+model.layers.*.feed_forward.router.weight: [fsdp, null]
+# hidden_size, intermediate_size    
+model.layers.*.feed_forward.shared_expert.gate_proj.weight: [tensor, fsdp]
+# hidden_size, intermediate_size    
+model.layers.*.feed_forward.shared_expert.up_proj.weight: [tensor, fsdp]
+# intermediate_size, hidden_size
+model.layers.*.feed_forward.shared_expert.down_proj.weight: [fsdp, tensor]
+# hidden_size
+model.layers.*.input_layernorm.weight: [fsdp]
+# hidden_size
+model.layers.*.post_attention_layernorm.weight: [fsdp]
+# hidden_size
+model.norm.weight: [fsdp]
+# hidden_size, vocab_size
+lm_head.weight: [tensor, fsdp]
+
+# Activations
+# batch, seq_len, hidden_dim
+model.layers.*: [[data, fsdp], null, null]
+lm_head: [[data, fsdp], null, null]

--- a/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp-tp.yaml
+++ b/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp-tp.yaml
@@ -35,6 +35,5 @@ model.norm.weight: [fsdp]
 lm_head.weight: [tensor, fsdp]
 
 # Activations
-# batch, seq_len, hidden_dim
-model.layers.*: [[data, fsdp], null, null]
-lm_head: [[data, fsdp], null, null]
+model.layers.*: [[data, fsdp], null, tensor]
+lm_head: [[data, fsdp], null, tensor]

--- a/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp.yaml
+++ b/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp.yaml
@@ -1,17 +1,34 @@
+# Weights
+# vocab_size, hidden_size
 model.embed_tokens.weight: [fsdp, null]
+# hidden_size, num_attention_heads * head_dim
 model.layers.*.self_attn.q_proj.weight: [fsdp, null]
-model.layers.*.self_attn.k_proj.weight: [null, fsdp]
-model.layers.*.self_attn.v_proj.weight: [null, fsdp]
-model.layers.*.self_attn.o_proj.weight: [fsdp, null]
-model.layers.*.feed_forward.experts.gate_up_proj: [fsdp, null, null]
-model.layers.*.feed_forward.experts.down_proj:  [fsdp, null, null]
+# hidden_size, num_key_value_heads * head_dim
+model.layers.*.self_attn.k_proj.weight: [fsdp, null]
+# hidden_size, num_key_value_heads * head_dim
+model.layers.*.self_attn.v_proj.weight: [fsdp, null]
+# hidden_size, hidden_size
+model.layers.*.self_attn.o_proj.weight: [null, fsdp]
+
+# num_experts, hidden_size, 2 * intermediate_size
+model.layers.*.feed_forward.experts.gate_up_proj: [null, fsdp, null]
+# num_experts, expert_dim, hidden_size
+model.layers.*.feed_forward.experts.down_proj:  [null, null, fsdp]
+# hidden_size, num_experts
 model.layers.*.feed_forward.router.weight: [fsdp, null]
+# hidden_size, intermediate_size
 model.layers.*.feed_forward.shared_expert.gate_proj.weight: [fsdp, null]
+# hidden_size, intermediate_size
 model.layers.*.feed_forward.shared_expert.up_proj.weight: [fsdp, null]
+# intermediate_size, hidden_size
 model.layers.*.feed_forward.shared_expert.down_proj.weight: [null, fsdp]
+# hidden_size
 model.layers.*.input_layernorm.weight: [fsdp]
+# hidden_size
 model.layers.*.post_attention_layernorm.weight: [fsdp]
+# hidden_size
 model.norm.weight: [fsdp]
+# hidden_size, vocab_size
 lm_head.weight: [fsdp, null]
 
 # Activations

--- a/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp.yaml
+++ b/torchprime/torch_xla_models/configs/model/sharding/llama4-fsdp.yaml
@@ -4,11 +4,11 @@ model.embed_tokens.weight: [fsdp, null]
 # hidden_size, num_attention_heads * head_dim
 model.layers.*.self_attn.q_proj.weight: [fsdp, null]
 # hidden_size, num_key_value_heads * head_dim
-model.layers.*.self_attn.k_proj.weight: [fsdp, null]
+model.layers.*.self_attn.k_proj.weight: [null, fsdp]
 # hidden_size, num_key_value_heads * head_dim
-model.layers.*.self_attn.v_proj.weight: [fsdp, null]
+model.layers.*.self_attn.v_proj.weight: [null, fsdp]
 # hidden_size, hidden_size
-model.layers.*.self_attn.o_proj.weight: [null, fsdp]
+model.layers.*.self_attn.o_proj.weight: [fsdp, null]
 
 # num_experts, hidden_size, 2 * intermediate_size
 model.layers.*.feed_forward.experts.gate_up_proj: [null, fsdp, null]

--- a/torchprime/torch_xla_models/model/llama4/model.py
+++ b/torchprime/torch_xla_models/model/llama4/model.py
@@ -19,19 +19,16 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/ll
 """
 
 from enum import Enum
+
 import torch
 import torch_xla.debug.profiler as xp
+import torch_xla.distributed.spmd as xs
 from omegaconf import DictConfig
 from torch import nn
+from torch_xla.distributed.spmd.xla_sharding import MarkShardingFunction
 from transformers.activations import ACT2FN
 from transformers.utils import logging
-import torch_xla.core.xla_model as xm
-import torch_xla.distributed.spmd as xs
-import torch_xla.runtime as xr
 
-import torch_xla
-
-from torch_xla.distributed.spmd.xla_sharding import MarkShardingFunction
 from torchprime.layers.sequential import HomogeneousSequential
 from torchprime.rope.rope import RopeScaling, llama3_rope_frequencies
 from torchprime.torch_xla_models import offloading
@@ -39,15 +36,13 @@ from torchprime.torch_xla_models.attention import AttentionModule
 from torchprime.torch_xla_models.loss import cross_entropy_loss
 from torchprime.torch_xla_models.model.base_causal_lm import BaseCausalLM
 
-from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
-
 logger = logging.get_logger(__name__)
 
 
 class MoeImplementation(str, Enum):
-    original = "original"
-    sequential = "sequential"
-    expert_parallelism = "expert_parallelism"
+  original = "original"
+  sequential = "sequential"
+  expert_parallelism = "expert_parallelism"
 
 
 class Llama4TextExperts(nn.Module):
@@ -148,6 +143,7 @@ class Llama4TextMoe(nn.Module):
   It is used to compare alternative implementations to original one
   for correctness.
   """
+
   def __init__(self, config):
     super().__init__()
     self.top_k = config.num_experts_per_tok
@@ -259,13 +255,14 @@ class Llama4TextMoeSequential(Llama4TextMoe):
 
     # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, sparse_router_scores.transpose(0, 1)
-    
+
+
 class Llama4TextMoeExpertParallelism(Llama4TextMoe):
   """Expert parallelism implementation of MOE layer.
 
   Note that this implementation needs mesh to be initialized in order for it
   to work properly.
-  """  
+  """
 
   @xp.trace_me("Llama4TextMoe")
   def forward(self, hidden_states):
@@ -305,10 +302,10 @@ class Llama4TextMoeExpertParallelism(Llama4TextMoe):
         routed_in, mesh, (("expert", "fsdp"), "tensor")
       )
       router_scores = MarkShardingFunction.apply(
-        router_scores, mesh, (("expert","fsdp"), "tensor")
+        router_scores, mesh, (("expert", "fsdp"), "tensor")
       )
     routed_in = routed_in * router_scores.reshape(-1, 1)
-    
+
     # Expert weights are expected to be sharded by expert dimension.
     # Therefore multiplication per expert should happen locally.
     routed_out = self.experts(routed_in)
@@ -320,7 +317,7 @@ class Llama4TextMoeExpertParallelism(Llama4TextMoe):
     out = routed_out.sum(dim=0) + self.shared_expert(hidden_states)
     # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, router_scores
-  
+
 
 class Llama4TextRotaryEmbedding(nn.Module):
   inv_freq: nn.Buffer

--- a/torchprime/torch_xla_models/model/llama4/model.py
+++ b/torchprime/torch_xla_models/model/llama4/model.py
@@ -185,7 +185,9 @@ class Llama4TextMoe(nn.Module):
     out = self.shared_expert(hidden_states)
     # Now that we finished expert computation -> we scatter add because we gathered previously.
     # W.e have to do this because we used all experts on all tokens.
-    out.scatter_add_(dim=0, index=router_indices, src=routed_out.view(-1, hidden_dim))
+    # Replacing by sum, as backwards pass in PyTorch/XLA has issues with scatter_add_
+    # out.scatter_add_(dim=0, index=router_indices, src=routed_out.view(-1, hidden_dim))
+    out += routed_out.sum(dim=0)
     # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, router_scores
 

--- a/torchprime/torch_xla_models/model/llama4/model.py
+++ b/torchprime/torch_xla_models/model/llama4/model.py
@@ -308,6 +308,7 @@ class Llama4TextMoeExpertParallelism(Llama4TextMoe):
     # Expert weights are expected to be sharded by expert dimension.
     # Therefore multiplication per expert should happen locally.
     routed_out = self.experts(routed_in)
+    routed_out = routed_out.reshape(self.num_experts, -1, self.hidden_dim).sum(dim=0)
     # Reshard back, by concatenating expert dimension and resharding by batch dimension.
     if mesh:
       routed_out = MarkShardingFunction.apply(
@@ -315,7 +316,7 @@ class Llama4TextMoeExpertParallelism(Llama4TextMoe):
       )
     out = self.shared_expert(hidden_states)
     # Combining results from all experts
-    out.add_(routed_out.reshape(self.num_experts, -1, self.hidden_dim).sum(dim=0))
+    out.add_(routed_out)
     # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, router_scores
 

--- a/torchprime/torch_xla_models/model/llama4/model.py
+++ b/torchprime/torch_xla_models/model/llama4/model.py
@@ -18,13 +18,20 @@ Modelled after:
 https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/modeling_llama4.py
 """
 
+from enum import Enum
 import torch
 import torch_xla.debug.profiler as xp
 from omegaconf import DictConfig
 from torch import nn
 from transformers.activations import ACT2FN
 from transformers.utils import logging
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
 
+import torch_xla
+
+from torch_xla.distributed.spmd.xla_sharding import MarkShardingFunction
 from torchprime.layers.sequential import HomogeneousSequential
 from torchprime.rope.rope import RopeScaling, llama3_rope_frequencies
 from torchprime.torch_xla_models import offloading
@@ -32,7 +39,15 @@ from torchprime.torch_xla_models.attention import AttentionModule
 from torchprime.torch_xla_models.loss import cross_entropy_loss
 from torchprime.torch_xla_models.model.base_causal_lm import BaseCausalLM
 
+from torch_xla.distributed.spmd.debugging import visualize_tensor_sharding
+
 logger = logging.get_logger(__name__)
+
+
+class MoeImplementation(str, Enum):
+    original = "original"
+    sequential = "sequential"
+    expert_parallelism = "expert_parallelism"
 
 
 class Llama4TextExperts(nn.Module):
@@ -127,6 +142,12 @@ class Llama4TextRMSNorm(nn.Module):
 
 
 class Llama4TextMoe(nn.Module):
+  """Original implementation of MOE layer from HF.
+
+  This implementation would likely to OOM on real model size.
+  It is used to compare alternative implementations to original one
+  for correctness.
+  """
   def __init__(self, config):
     super().__init__()
     self.top_k = config.num_experts_per_tok
@@ -138,42 +159,168 @@ class Llama4TextMoe(nn.Module):
 
   @xp.trace_me("Llama4TextMoe")
   def forward(self, hidden_states):
+    # batch, seq_len, hidden_dim is the shape of hidden states
     batch, seq_len, hidden_dim = hidden_states.shape
     hidden_states = hidden_states.view(-1, self.hidden_dim)
+    # Get routed logits for each token
+    # Dimensions: [batch * seq_len, num_experts]
     router_logits = self.router(hidden_states)
-    tokens_per_expert = batch * seq_len
 
+    # Find the top K experts and their scores for each token
+    # router_top_value, router_indices: [batch * seq_len, top_k]
     router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=1)
+
+    # Create a score mask to keep only the top-k scores
+    # Dimensions: [num_experts, batch * seq_len]
     router_scores = (
       torch.full_like(router_logits, float("-inf"))
       .scatter_(1, router_indices, router_top_value)
       .transpose(0, 1)
     )
-    # We do this to make sure we have -inf for non topK tokens before going through the !
-    # Here we are just creating a tensor to index each and every single one of the hidden states. Let s maybe register a buffer for this!
-    router_indices = (
-      torch.arange(tokens_per_expert, device=hidden_states.device)
-      .view(1, -1)
-      .expand(router_scores.size(0), -1)
-    )
     router_scores = torch.sigmoid(router_scores.float()).to(hidden_states.dtype)
 
-    router_indices = router_indices.reshape(-1, 1).expand(-1, hidden_dim)
-    routed_in = torch.gather(
-      input=hidden_states,
-      dim=0,
-      index=router_indices,
-    ).to(hidden_states.device)
-    # we gather inputs corresponding to each expert based on the router indices
+    # Repeating hidden_states for num_experts
+    # This is a huge tensor, dimensions would be:
+    # [num_experts * batch * seq_len, hidden_dim]
+    routed_in = hidden_states.repeat(self.num_experts, 1)
+    # Following line would likely OOM on materialization of routed_in tensor.
     routed_in = routed_in * router_scores.reshape(-1, 1)
     routed_out = self.experts(routed_in)
     out = self.shared_expert(hidden_states)
-    # now that we finished expert computation -> we scatter add because we gathered previously
-    # we have to do this because we used all experts on all tokens. This is faster than the for loop, tho you are compute bound
-    # this scales a lot better if you do EP!
+    # Now that we finished expert computation -> we scatter add because we gathered previously.
+    # W.e have to do this because we used all experts on all tokens.
     out.scatter_add_(dim=0, index=router_indices, src=routed_out.view(-1, hidden_dim))
+    # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, router_scores
 
+
+class Llama4TextMoeSequential(Llama4TextMoe):
+  """Naive sequential implementation of MOE layer.
+
+  This implementation iterates over experts one by one wich is slow
+  but memory efficient. It is presented here mostly for educational purposes.
+  """
+
+  @xp.trace_me("Llama4TextMoe")
+  def forward(self, hidden_states):
+    """
+    This version processes experts sequentially to save memory. It is slower
+    but avoids the large intermediate tensor that can cause OOM errors.
+    """
+    batch, seq_len, hidden_dim = hidden_states.shape
+    hidden_states_flat = hidden_states.view(-1, self.hidden_dim)
+
+    # Dimensions: [batch * seq_len, num_experts]
+    router_logits = self.router(hidden_states_flat)
+
+    # Find the top K experts and their scores for each token
+    # router_top_value, router_indices: [batch * seq_len, top_k]
+    router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=1)
+
+    # Zero out logits that didn't make to topk
+    # Dimensions: [batch * seq_len, num_experts]
+    sparse_router_scores = torch.full_like(router_logits, float("-inf")).scatter_(
+      1, router_indices, router_top_value
+    )
+    # Dimensions: [batch * seq_len, num_experts]
+    sparse_router_scores = torch.sigmoid(sparse_router_scores.float()).to(
+      hidden_states.dtype
+    )
+
+    out = self.shared_expert(hidden_states_flat)
+
+    def process_expert(i):
+      # dimensions: (hidden_dim, 2 * intermediate_dim)
+      expert_weights = self.experts.gate_up_proj[i]
+
+      # dimensions: (batch * seq_len)
+      router_scores_for_expert = sparse_router_scores[:, i]
+
+      # (batch * seq_len, hidden_dim) @ (hidden_dim, 2*expert_dim)
+      # -> (batch * seq_len, 2*expert_dim)
+      gate_up = hidden_states_flat @ expert_weights
+
+      gate_up = gate_up * router_scores_for_expert.unsqueeze(1)
+
+      gate, up = gate_up.chunk(2, dim=-1)
+      # (batch * seq_len, expert_dim)
+      act_fn_out = up * self.experts.act_fn(gate)
+      # (expert_dim, hidden_dim)
+      down_proj_weights = self.experts.down_proj[i]
+
+      # (batch * seq_len, expert_dim) @ (expert_dim, hidden_dim)
+      # -> (batch * seq_len, hidden_dim)
+      # This op is prone to OOM
+      expert_output = act_fn_out @ down_proj_weights
+      return expert_output
+
+    for i in range(self.num_experts):
+      out += process_expert(i)
+
+    # No need to reshape output back to [batch, seq_len, hidden_dim]
+    return out, sparse_router_scores.transpose(0, 1)
+    
+class Llama4TextMoeExpertParallelism(Llama4TextMoe):
+  """Expert parallelism implementation of MOE layer.
+
+  Note that this implementation needs mesh to be initialized in order for it
+  to work properly.
+  """  
+
+  @xp.trace_me("Llama4TextMoe")
+  def forward(self, hidden_states):
+    mesh = xs.get_global_mesh()
+
+    # batch, seq_len, hidden_dim is the shape of hidden states
+    batch, seq_len, hidden_dim = hidden_states.shape
+    # [batch * seq_len, hidden_dim]
+    hidden_states = hidden_states.view(-1, self.hidden_dim)
+    # Get routed logits for each token
+    # Dimensions: [batch * seq_len, num_experts]
+    router_logits = self.router(hidden_states)
+
+    # Find the top K experts and their scores for each token
+    # router_top_value, router_indices: [batch * seq_len, top_k]
+    router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=1)
+
+    # Create a score mask to keep only the top-k scores
+    # Dimensions: [num_experts, batch * seq_len]
+    router_scores = (
+      torch.full_like(router_logits, float("-inf"))
+      .scatter_(1, router_indices, router_top_value)
+      .transpose(0, 1)
+    )
+    router_scores = torch.sigmoid(router_scores.float()).to(hidden_states.dtype)
+
+    # Repeating hidden_states for num_experts
+    # This is a huge tensor, dimensions would be:
+    # [num_experts * batch * seq_len, hidden_dim]
+    routed_in = hidden_states.repeat(self.num_experts, 1)
+
+    # This should trigger all-to-all to reshard routed_in to assign
+    # data for specific expert to a specific device by replacing
+    # data dimension sharding by expert.
+    if mesh:
+      routed_in = MarkShardingFunction.apply(
+        routed_in, mesh, (("expert", "fsdp"), "tensor")
+      )
+      router_scores = MarkShardingFunction.apply(
+        router_scores, mesh, (("expert","fsdp"), "tensor")
+      )
+    routed_in = routed_in * router_scores.reshape(-1, 1)
+    
+    # Expert weights are expected to be sharded by expert dimension.
+    # Therefore multiplication per expert should happen locally.
+    routed_out = self.experts(routed_in)
+    # Reshard back, by concatenating expert dimension and resharding by batch dimension.
+    if mesh:
+      routed_out = MarkShardingFunction.apply(
+        routed_out, mesh, (("data", "fsdp"), "tensor")
+      )
+    out = routed_out.sum(dim=0) + self.shared_expert(hidden_states)
+    # No need to reshape output back to [batch, seq_len, hidden_dim]
+    return out, router_scores
+  
 
 class Llama4TextRotaryEmbedding(nn.Module):
   inv_freq: nn.Buffer
@@ -402,7 +549,15 @@ class Llama4TextDecoderLayer(nn.Module):
     )
     self.is_moe_layer = layer_idx in config.moe_layers
     if self.is_moe_layer:  # the 128E model interleaves dense / sparse
-      self.feed_forward = Llama4TextMoe(config)
+      match config.moe_implementation:
+        case MoeImplementation.expert_parallelism:
+          self.feed_forward = Llama4TextMoeExpertParallelism(config)
+        case MoeImplementation.sequential:
+          self.feed_forward = Llama4TextMoeSequential(config)
+        case MoeImplementation.original:
+          self.feed_forward = Llama4TextMoe(config)
+        case _:
+          self.feed_forward = Llama4TextMoe(config)
     else:
       self.feed_forward = Llama4TextMLP(
         config, intermediate_size=config.intermediate_size_mlp

--- a/torchprime/torch_xla_models/model/llama4/model.py
+++ b/torchprime/torch_xla_models/model/llama4/model.py
@@ -183,11 +183,8 @@ class Llama4TextMoe(nn.Module):
     routed_in = routed_in * router_scores.reshape(-1, 1)
     routed_out = self.experts(routed_in)
     out = self.shared_expert(hidden_states)
-    # Now that we finished expert computation -> we scatter add because we gathered previously.
-    # W.e have to do this because we used all experts on all tokens.
-    # Replacing by sum, as backwards pass in PyTorch/XLA has issues with scatter_add_
-    # out.scatter_add_(dim=0, index=router_indices, src=routed_out.view(-1, hidden_dim))
-    out += routed_out.sum(dim=0)
+    # Combining results from all experts
+    out.add_(routed_out.reshape(self.num_experts, -1, self.hidden_dim).sum(dim=0))
     # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, router_scores
 
@@ -301,10 +298,10 @@ class Llama4TextMoeExpertParallelism(Llama4TextMoe):
     # data dimension sharding by expert.
     if mesh:
       routed_in = MarkShardingFunction.apply(
-        routed_in, mesh, (("expert", "fsdp"), "tensor")
+        routed_in, mesh, (("expert", "data", "fsdp"), "tensor")
       )
       router_scores = MarkShardingFunction.apply(
-        router_scores, mesh, (("expert", "fsdp"), "tensor")
+        router_scores, mesh, (("expert", "data", "fsdp"), "tensor")
       )
     routed_in = routed_in * router_scores.reshape(-1, 1)
 
@@ -316,7 +313,9 @@ class Llama4TextMoeExpertParallelism(Llama4TextMoe):
       routed_out = MarkShardingFunction.apply(
         routed_out, mesh, (("data", "fsdp"), "tensor")
       )
-    out = routed_out.sum(dim=0) + self.shared_expert(hidden_states)
+    out = self.shared_expert(hidden_states)
+    # Combining results from all experts
+    out.add_(routed_out.reshape(self.num_experts, -1, self.hidden_dim).sum(dim=0))
     # No need to reshape output back to [batch, seq_len, hidden_dim]
     return out, router_scores
 

--- a/torchprime/torch_xla_models/tests/test_llama4.py
+++ b/torchprime/torch_xla_models/tests/test_llama4.py
@@ -23,7 +23,8 @@ class LlamaFixture:
 
 
 def get_llama_4_text_dummy_model(
-  moe_implementation: modeling_llama4.MoeImplementation = None) -> LlamaFixture:
+  moe_implementation: modeling_llama4.MoeImplementation = None,
+) -> LlamaFixture:
   torch.manual_seed(42)
   torch_xla.manual_seed(42)
   vocab_size = 128
@@ -222,9 +223,11 @@ def test_moe_layer_from_model(fixture):
   model_xla.eval()
   moe_layer = model_xla.model.layers[0].feed_forward
   assert isinstance(moe_layer, modeling_llama4.Llama4TextMoe)
-  hidden_states = torch.rand(batch_size, seq_len, model_xla.config.hidden_size).to(device)
+  hidden_states = torch.rand(batch_size, seq_len, model_xla.config.hidden_size).to(
+    device
+  )
   out_original, scores_original = moe_layer.forward(hidden_states)
-  torch_xla.sync()  
+  torch_xla.sync()
 
   # Model with sequential MOE layer implementation
   fixture_seq = fixture(moe_implementation=modeling_llama4.MoeImplementation.sequential)
@@ -236,7 +239,9 @@ def test_moe_layer_from_model(fixture):
   torch_xla.sync()
 
   # Model with Expert Parallelism implementation
-  fixture_exp = fixture(moe_implementation=modeling_llama4.MoeImplementation.expert_parallelism)
+  fixture_exp = fixture(
+    moe_implementation=modeling_llama4.MoeImplementation.expert_parallelism
+  )
   model_exp = copy.deepcopy(fixture_exp.model).to(device)
   model_exp.eval()
   moe_layer_exp = model_exp.model.layers[0].feed_forward
@@ -245,10 +250,12 @@ def test_moe_layer_from_model(fixture):
   torch_xla.sync()
 
   # Assert
-  assert out_original.size() == out_seq.size(), \
+  assert out_original.size() == out_seq.size(), (
     "Dimensions for outputs tensors don't match for seq MOE"
-  assert scores_original.size() == scores_seq.size(), \
+  )
+  assert scores_original.size() == scores_seq.size(), (
     "Dimensions for scores don't match for seq MOE"
+  )
 
   torch.testing.assert_close(
     out_original,
@@ -265,10 +272,12 @@ def test_moe_layer_from_model(fixture):
     msg="sequential MoE layer scores do not match original logic",
   )
 
-  assert out_original.size() == out_seq.size(), \
+  assert out_original.size() == out_seq.size(), (
     "Dimensions for outputs tensors don't match for expert parallelism MOE"
-  assert scores_original.size() == scores_seq.size(), \
+  )
+  assert scores_original.size() == scores_seq.size(), (
     "Dimensions for scores don't match for expert parallelism MOE"
+  )
 
   torch.testing.assert_close(
     out_original,

--- a/torchprime/torch_xla_models/tests/test_llama4.py
+++ b/torchprime/torch_xla_models/tests/test_llama4.py
@@ -22,7 +22,8 @@ class LlamaFixture:
   model_config: DictConfig
 
 
-def get_llama_4_text_dummy_model() -> LlamaFixture:
+def get_llama_4_text_dummy_model(
+  moe_implementation: modeling_llama4.MoeImplementation = None) -> LlamaFixture:
   torch.manual_seed(42)
   torch_xla.manual_seed(42)
   vocab_size = 128
@@ -30,6 +31,8 @@ def get_llama_4_text_dummy_model() -> LlamaFixture:
     "meta-llama/Llama-4-Scout-17B-16E",
   )
   config.text_config.num_hidden_layers = 1
+  config.text_config.num_local_experts = 4
+  config.text_config.moe_layers = [0]
   config.text_config.vocab_size = vocab_size
   config.text_config.head_dim = 64
   config.text_config.num_attention_heads = 8
@@ -44,6 +47,7 @@ def get_llama_4_text_dummy_model() -> LlamaFixture:
   del torchprime_config.text_config.rope_scaling.original_max_position_embeddings
   del torchprime_config.text_config.rope_scaling.rope_type
   torchprime_config.text_config.attention_kernel = None
+  torchprime_config.text_config.moe_implementation = moe_implementation
 
   # Place model on CPU device first
   with torch.device("cpu"):
@@ -191,3 +195,92 @@ def test_rotarty_embedding_our_model_against_hf_model_native(fixture):
       rtol=1e-6,
       msg="xk after apply_rotary_emb is not equal",
     )
+
+
+@pytest.mark.parametrize(
+  "fixture",
+  [get_llama_4_text_dummy_model],
+  ids=["Llama4 dummy model"],
+)
+def test_moe_layer_from_model(fixture):
+  """
+  Tests the Llama4TextMoe layer from a loaded model to verify that the
+  memory-efficient `forward` method is mathematically equivalent to the
+  `forward_original` method.
+  """
+  # Arrange
+  device = torch.device("xla")
+  torch.manual_seed(42)
+
+  # Create dummy input
+  batch_size = 2
+  seq_len = 16
+
+  # Act
+  # Model with original MOE layer implementation
+  model_xla = copy.deepcopy(fixture().model).to(device)
+  model_xla.eval()
+  moe_layer = model_xla.model.layers[0].feed_forward
+  assert isinstance(moe_layer, modeling_llama4.Llama4TextMoe)
+  hidden_states = torch.rand(batch_size, seq_len, model_xla.config.hidden_size).to(device)
+  out_original, scores_original = moe_layer.forward(hidden_states)
+  torch_xla.sync()  
+
+  # Model with sequential MOE layer implementation
+  fixture_seq = fixture(moe_implementation=modeling_llama4.MoeImplementation.sequential)
+  model_seq = copy.deepcopy(fixture_seq.model).to(device)
+  model_seq.eval()
+  moe_layer_seq = model_seq.model.layers[0].feed_forward
+  assert isinstance(moe_layer_seq, modeling_llama4.Llama4TextMoeSequential)
+  out_seq, scores_seq = moe_layer.forward(hidden_states)
+  torch_xla.sync()
+
+  # Model with Expert Parallelism implementation
+  fixture_exp = fixture(moe_implementation=modeling_llama4.MoeImplementation.expert_parallelism)
+  model_exp = copy.deepcopy(fixture_exp.model).to(device)
+  model_exp.eval()
+  moe_layer_exp = model_exp.model.layers[0].feed_forward
+  assert isinstance(moe_layer_exp, modeling_llama4.Llama4TextMoeExpertParallelism)
+  out_exp, scores_exp = moe_layer.forward(hidden_states)
+  torch_xla.sync()
+
+  # Assert
+  assert out_original.size() == out_seq.size(), \
+    "Dimensions for outputs tensors don't match for seq MOE"
+  assert scores_original.size() == scores_seq.size(), \
+    "Dimensions for scores don't match for seq MOE"
+
+  torch.testing.assert_close(
+    out_original,
+    out_seq,
+    atol=1e-2,
+    rtol=1e-6,
+    msg="sequential MoE layer output does not match original logic",
+  )
+  torch.testing.assert_close(
+    scores_original,
+    scores_seq,
+    atol=1e-3,
+    rtol=1e-6,
+    msg="sequential MoE layer scores do not match original logic",
+  )
+
+  assert out_original.size() == out_seq.size(), \
+    "Dimensions for outputs tensors don't match for expert parallelism MOE"
+  assert scores_original.size() == scores_seq.size(), \
+    "Dimensions for scores don't match for expert parallelism MOE"
+
+  torch.testing.assert_close(
+    out_original,
+    out_exp,
+    atol=1e-2,
+    rtol=1e-6,
+    msg="expert parallelism MoE layer output does not match original logic",
+  )
+  torch.testing.assert_close(
+    scores_original,
+    scores_exp,
+    atol=1e-3,
+    rtol=1e-6,
+    msg="expert parallelism MoE layer scores do not match original logic",
+  )

--- a/torchprime/torch_xla_models/tests/test_llama4.py
+++ b/torchprime/torch_xla_models/tests/test_llama4.py
@@ -96,7 +96,7 @@ def test_forward_our_model_against_hf_model(fixture, transform):
     torch.testing.assert_close(
       hf_output.logits,
       llama_xla_logits,
-      atol=1e-5,
+      atol=1e-4,
       rtol=1e-9,
       msg="logits are not equal",
     )

--- a/torchprime/torch_xla_models/tests/test_llama4.py
+++ b/torchprime/torch_xla_models/tests/test_llama4.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 
 import pytest
 import torch
-import torch.test
 import torch_xla
 import transformers.models.llama4.modeling_llama4 as hf_modeling_llama4
 from omegaconf import DictConfig, OmegaConf
@@ -260,36 +259,36 @@ def test_moe_layer_from_model(fixture):
   torch.testing.assert_close(
     out_original,
     out_seq,
-    atol=1e-2,
+    atol=1e-5,
     rtol=1e-6,
     msg="sequential MoE layer output does not match original logic",
   )
   torch.testing.assert_close(
     scores_original,
     scores_seq,
-    atol=1e-3,
+    atol=1e-5,
     rtol=1e-6,
     msg="sequential MoE layer scores do not match original logic",
   )
 
-  assert out_original.size() == out_seq.size(), (
+  assert out_original.size() == out_exp.size(), (
     "Dimensions for outputs tensors don't match for expert parallelism MOE"
   )
-  assert scores_original.size() == scores_seq.size(), (
+  assert scores_original.size() == scores_exp.size(), (
     "Dimensions for scores don't match for expert parallelism MOE"
   )
 
   torch.testing.assert_close(
     out_original,
     out_exp,
-    atol=1e-2,
+    atol=1e-5,
     rtol=1e-6,
     msg="expert parallelism MoE layer output does not match original logic",
   )
   torch.testing.assert_close(
     scores_original,
     scores_exp,
-    atol=1e-3,
+    atol=1e-5,
     rtol=1e-6,
     msg="expert parallelism MoE layer scores do not match original logic",
   )


### PR DESCRIPTION
Was able to run it as:
tp run --name alekseyv-llama-4-18-ep \
    torchprime/torch_xla_models/train.py \
    model=llama-4-text-only-scout-17b-16e \
    task.global_batch_size=256 \
    ici_mesh.fsdp=16 \
    ici_mesh.data=1 \
    ici_mesh.expert=16 \
    dataset.block_size=512 \
    model/sharding=llama4-fsdp-tp-ep

Performance is still not great