### PR TITLE
Load Huggingface dataset from a GCS cache

### DIFF
--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -9,9 +9,7 @@ from transformers.tokenization_utils import PreTrainedTokenizerBase
 from torchprime.torch_xla_models.model import model_utils
 
 
-def _load_preprocessed_dataset(
-  path: str, split: str, cache_dir: str | None
-) -> Dataset:
+def _load_preprocessed_dataset(path: str, split: str, cache_dir: str | None) -> Dataset:
   """Loads a `datasets` object from a directory saved with `save_to_disk`.
 
   Handles both local paths and GCS URIs. If a GCS path is provided, the data is

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -3,8 +3,31 @@
 import json
 
 import fsspec
-from datasets import Dataset, DatasetDict, load_dataset
+from datasets import Dataset, DatasetDict, load_dataset, load_from_disk
 from transformers.tokenization_utils import PreTrainedTokenizerBase
+
+from torchprime.torch_xla_models.model import model_utils
+
+
+def _load_preprocessed_dataset(path: str, cache_dir: str | None) -> Dataset | DatasetDict:
+  """Loads a `datasets` object from a directory saved with `save_to_disk`.
+
+  Handles both local paths and GCS URIs. If a GCS path is provided, the data is
+  first downloaded to a local temporary directory.
+
+  Args:
+    path: The path to the dataset directory (local or GCS).
+    cache_dir: Optional temporary directory for GCS downloads.
+
+  Returns:
+    The loaded `datasets.Dataset` or `datasets.DatasetDict` object.
+  """
+  if path.startswith("gs://"):
+    with model_utils.local_path_from_gcs(
+      path, temp_dir=cache_dir
+    ) as local_path:
+      return load_from_disk(local_path)
+  return load_from_disk(path)
 
 
 def _load_json_dataset(path: str, split: str) -> Dataset:
@@ -92,32 +115,53 @@ def make_train_dataset(
   hf_dataset_name: str | None = None,
   hf_dataset_config_name: str | None = None,
   file_dataset_path: str | None = None,
+  is_preprocessed: bool = False,
   split: str = "train",
   cache_dir: str | None = None,
   *,
   tokenizer: PreTrainedTokenizerBase,
   block_size: int,
 ) -> Dataset:
-  """Loads and tokenizes a dataset, then chunks it into fixed-size blocks for training.
+  """Loads a dataset, tokenizes it, and chunks it into fixed-size blocks.
 
   This function downloads a dataset from the Hugging Face Hub, tokenizes the `text`
   column using the provided tokenizer, and groups the resulting tokens into
   contiguous blocks of fixed length (`block_size`). This block-wise packing is useful
   for efficient language modeling, especially on accelerators like TPUs.
 
+  If `is_preprocessed` is True, the function loads a dataset directly from the
+  path specified in `hf_dataset_name` or `file_dataset_path`, skipping tokenization.
+
   Args:
     hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
     hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
     file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
+    is_preprocessed: If True, load a pre-tokenized dataset from disk.
     split: Dataset split to load from HF. (e.g., "train", "validation").
     cache_dir: Optional directory for HF dataset cache.
     tokenizer: A Hugging Face tokenizer used to tokenize the input text.
     block_size: The fixed length of each chunked training example.
 
   Returns:
-    A `Dataset` object containing tokenized and block-wise grouped training examples,
-    each with keys `"input_ids"` and `"labels"`.
+    A `Dataset` object with tokenized and block-wise grouped training examples.
   """
+  if is_preprocessed:
+    path = hf_dataset_name or file_dataset_path
+    if not path:
+      raise ValueError(
+        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
+      )
+    data = _load_preprocessed_dataset(path, cache_dir)
+    if isinstance(data, DatasetDict):
+      data = data[split]
+
+    # Ensure required columns exist for training.
+    if "input_ids" not in data.features or "labels" not in data.features:
+      raise ValueError(
+        "Pre-processed dataset is missing 'input_ids' or 'labels' column, which are required for training."
+      )
+    return data
+
   data = load_hf_or_json_dataset(
     hf_dataset_name=hf_dataset_name,
     hf_dataset_config_name=hf_dataset_config_name,

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -57,11 +57,15 @@ def _load_hf_dataset(
   split: str,
   cache_dir: str | None,
 ) -> Dataset:
-  """Download and return a dataset from Hugging Face Hub.
+  """Load a dataset from Hugging Face Hub or a GCS path.
+
+  If `name` is a GCS path (starts with 'gs://'), it loads a `datasets` object
+  from a directory saved with `save_to_disk`. Otherwise, it downloads and
+  returns a dataset from Hugging Face Hub.
 
   Args:
-    name: Name of the dataset on the hub.
-    config: Optional configuration name.
+    name: Name of the dataset on the hub, or a GCS path to a saved dataset.
+    config: Optional configuration name for datasets from the Hub.
     split: Split to load.
     cache_dir: Directory where the dataset cache should live.
 
@@ -126,7 +130,7 @@ def make_train_dataset(
   tokenizer: PreTrainedTokenizerBase,
   block_size: int,
 ) -> Dataset:
-  """Loads a dataset, tokenizes it, and chunks it into fixed-size blocks.
+  """Loads and tokenizes a dataset, then chunks it into fixed-size blocks for training.
 
   This function downloads a dataset from the Hugging Face Hub, tokenizes the `text`
   column using the provided tokenizer, and groups the resulting tokens into

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -9,7 +9,9 @@ from transformers.tokenization_utils import PreTrainedTokenizerBase
 from torchprime.torch_xla_models.model import model_utils
 
 
-def _load_preprocessed_dataset(path: str, cache_dir: str | None) -> Dataset | DatasetDict:
+def _load_preprocessed_dataset(
+  path: str, cache_dir: str | None
+) -> Dataset | DatasetDict:
   """Loads a `datasets` object from a directory saved with `save_to_disk`.
 
   Handles both local paths and GCS URIs. If a GCS path is provided, the data is
@@ -23,9 +25,7 @@ def _load_preprocessed_dataset(path: str, cache_dir: str | None) -> Dataset | Da
     The loaded `datasets.Dataset` or `datasets.DatasetDict` object.
   """
   if path.startswith("gs://"):
-    with model_utils.local_path_from_gcs(
-      path, temp_dir=cache_dir
-    ) as local_path:
+    with model_utils.local_path_from_gcs(path, temp_dir=cache_dir) as local_path:
       return load_from_disk(local_path)
   return load_from_disk(path)
 

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -84,8 +84,6 @@ def load_hf_or_json_dataset(
   if hf_dataset_name:
     data = _load_hf_dataset(hf_dataset_name, hf_dataset_config_name, split, cache_dir)
   elif file_dataset_path:
-    if split is None:
-      raise ValueError("Loading all splits is not supported for a single JSONL file.")
     data = _load_json_dataset(file_dataset_path, split)
   else:
     raise ValueError("Either hf_dataset_name or file_dataset_path must be provided")

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -10,24 +10,30 @@ from torchprime.torch_xla_models.model import model_utils
 
 
 def _load_preprocessed_dataset(
-  path: str, cache_dir: str | None
-) -> Dataset | DatasetDict:
+  path: str, split: str, cache_dir: str | None
+) -> Dataset:
   """Loads a `datasets` object from a directory saved with `save_to_disk`.
 
   Handles both local paths and GCS URIs. If a GCS path is provided, the data is
-  first downloaded to a local temporary directory.
+  first downloaded to a local temporary directory. If the loaded object is a
+  `DatasetDict`, the specified `split` is returned.
 
   Args:
     path: The path to the dataset directory (local or GCS).
+    split: The dataset split to load.
     cache_dir: Optional temporary directory for GCS downloads.
 
   Returns:
-    The loaded `datasets.Dataset` or `datasets.DatasetDict` object.
+    The loaded `datasets.Dataset` object.
   """
   if path.startswith("gs://"):
     with model_utils.local_path_from_gcs(path, temp_dir=cache_dir) as local_path:
-      return load_from_disk(local_path)
-  return load_from_disk(path)
+      data = load_from_disk(local_path)
+  else:
+    data = load_from_disk(path)
+  if isinstance(data, DatasetDict):
+    return data[split]
+  return data
 
 
 def _load_json_dataset(path: str, split: str) -> Dataset:
@@ -84,35 +90,31 @@ def _load_hf_dataset(
   return data
 
 
-def load_hf_or_json_dataset(
-  hf_dataset_name: str | None = None,
-  hf_dataset_config_name: str | None = None,
-  file_dataset_path: str | None = None,
+def _load_raw_dataset(
+  path_or_name: str,
+  config_name: str | None = None,
   split: str = "train",
   cache_dir: str | None = None,
 ):
-  """Loads a dataset either from Hugging Face Hub or a local/remote JSONL file.
+  """Loads a raw dataset from Hugging Face Hub, a GCS path, or a JSONL file.
 
   This function abstracts the logic for loading datasets from two sources:
-  1. Hugging Face Hub via `datasets.load_dataset`.
-  2. JSONL files (either local or `gs://`-hosted) using `fsspec`.
+  1. Hugging Face Hub or a pre-saved GCS dataset directory.
+  2. A JSONL file (local or `gs://`-hosted).
 
   Args:
-    hf_dataset_name: Optional name of the HF dataset.
-    hf_dataset_config_name: Optional configuration name for the HF dataset.
-    file_dataset_path: Optional path to a JSONL file (local or remote).
+    path_or_name: Name of the HF dataset, or a path to a JSONL file or GCS directory.
+    config_name: Optional configuration name for the HF dataset.
     split: Dataset split to load (default is "train").
     cache_dir: Optional directory to use for dataset caching (HF only).
 
   Returns:
     A HuggingFace ``Dataset`` instance.
   """
-  if hf_dataset_name:
-    data = _load_hf_dataset(hf_dataset_name, hf_dataset_config_name, split, cache_dir)
-  elif file_dataset_path:
-    data = _load_json_dataset(file_dataset_path, split)
+  if path_or_name.endswith((".json", ".jsonl")):
+    data = _load_json_dataset(path_or_name, split)
   else:
-    raise ValueError("Either hf_dataset_name or file_dataset_path must be provided")
+    data = _load_hf_dataset(path_or_name, config_name, split, cache_dir)
 
   assert isinstance(data, Dataset), "Loaded dataset must be a Dataset instance."
 
@@ -120,9 +122,8 @@ def load_hf_or_json_dataset(
 
 
 def make_train_dataset(
-  hf_dataset_name: str | None = None,
-  hf_dataset_config_name: str | None = None,
-  file_dataset_path: str | None = None,
+  dataset_path_or_name: str,
+  dataset_config_name: str | None = None,
   is_preprocessed: bool = False,
   split: str = "train",
   cache_dir: str | None = None,
@@ -130,7 +131,7 @@ def make_train_dataset(
   tokenizer: PreTrainedTokenizerBase,
   block_size: int,
 ) -> Dataset:
-  """Loads and tokenizes a dataset, then chunks it into fixed-size blocks for training.
+  """Load and prepare a dataset for causal language model training.
 
   This function downloads a dataset from the Hugging Face Hub, tokenizes the `text`
   column using the provided tokenizer, and groups the resulting tokens into
@@ -138,13 +139,12 @@ def make_train_dataset(
   for efficient language modeling, especially on accelerators like TPUs.
 
   If `is_preprocessed` is True, the function loads a dataset directly from the
-  path specified in `hf_dataset_name` or `file_dataset_path`, skipping tokenization.
+  path specified in `dataset_path_or_name`, skipping tokenization.
 
   Args:
-    hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
-    hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
-    file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
-    is_preprocessed: If True, load a pre-tokenized dataset from disk.
+    dataset_path_or_name: HF dataset name, or a path to a local/GCS dataset.
+    dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
+    is_preprocessed: If True, load a pre-tokenized dataset directly from the path.
     split: Dataset split to load from HF. (e.g., "train", "validation").
     cache_dir: Optional directory for HF dataset cache.
     tokenizer: A Hugging Face tokenizer used to tokenize the input text.
@@ -154,26 +154,16 @@ def make_train_dataset(
     A `Dataset` object with tokenized and block-wise grouped training examples.
   """
   if is_preprocessed:
-    path = hf_dataset_name or file_dataset_path
-    if not path:
-      raise ValueError(
-        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
-      )
-    data = _load_preprocessed_dataset(path, cache_dir)
-    if isinstance(data, DatasetDict):
-      data = data[split]
-
-    # Ensure required columns exist for training.
+    data = _load_preprocessed_dataset(dataset_path_or_name, split, cache_dir)
     if "input_ids" not in data.features or "labels" not in data.features:
       raise ValueError(
         "Pre-processed dataset is missing 'input_ids' or 'labels' column, which are required for training."
       )
     return data
 
-  data = load_hf_or_json_dataset(
-    hf_dataset_name=hf_dataset_name,
-    hf_dataset_config_name=hf_dataset_config_name,
-    file_dataset_path=file_dataset_path,
+  data = _load_raw_dataset(
+    path_or_name=dataset_path_or_name,
+    config_name=dataset_config_name,
     split=split,
     cache_dir=cache_dir,
   )

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -90,9 +90,9 @@ def load_hf_or_json_dataset(
   else:
     raise ValueError("Either hf_dataset_name or file_dataset_path must be provided")
 
-  assert isinstance(
-    data, Dataset | DatasetDict
-  ), "Loaded dataset must be a Dataset or DatasetDict instance."
+  assert isinstance(data, Dataset | DatasetDict), (
+    "Loaded dataset must be a Dataset or DatasetDict instance."
+  )
 
   return data
 

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -113,8 +113,8 @@ def make_train_dataset(
   contiguous blocks of fixed length (`block_size`). This block-wise packing is useful
   for efficient language modeling, especially on accelerators like TPUs.
 
-  If `is_preprocessed` is True, the function loads a dataset directly from the
-  path specified in `hf_dataset_name` or `file_dataset_path`, skipping tokenization.
+  If `is_preprocessed` is True, the function loads a dataset directly from the path
+  specified in `hf_dataset_name`, skipping tokenization.
 
   Args:
     hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -69,7 +69,11 @@ def _load_hf_dataset(
     The loaded ``Dataset`` instance for ``split``.
   """
 
-  data = load_dataset(name, config, split=split, cache_dir=cache_dir)
+  if name.startswith("gs://"):
+    with model_utils.local_path_from_gcs(name, temp_dir=cache_dir) as local_path:
+      data = load_from_disk(local_path)
+  else:
+    data = load_dataset(name, config, split=split, cache_dir=cache_dir)
   assert isinstance(data, Dataset | DatasetDict)
   if isinstance(data, DatasetDict):
     data = data[split]

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -9,31 +9,6 @@ from transformers.tokenization_utils import PreTrainedTokenizerBase
 from torchprime.torch_xla_models.model import model_utils
 
 
-def _load_preprocessed_dataset(path: str, split: str, cache_dir: str | None) -> Dataset:
-  """Loads a `datasets` object from a directory saved with `save_to_disk`.
-
-  Handles both local paths and GCS URIs. If a GCS path is provided, the data is
-  first downloaded to a local temporary directory. If the loaded object is a
-  `DatasetDict`, the specified `split` is returned.
-
-  Args:
-    path: The path to the dataset directory (local or GCS).
-    split: The dataset split to load.
-    cache_dir: Optional temporary directory for GCS downloads.
-
-  Returns:
-    The loaded `datasets.Dataset` object.
-  """
-  if path.startswith("gs://"):
-    with model_utils.local_path_from_gcs(path, temp_dir=cache_dir) as local_path:
-      data = load_from_disk(local_path)
-  else:
-    data = load_from_disk(path)
-  if isinstance(data, DatasetDict):
-    return data[split]
-  return data
-
-
 def _load_json_dataset(path: str, split: str) -> Dataset:
   """Load a dataset from a JSON Lines file.
 
@@ -58,32 +33,27 @@ def _load_json_dataset(path: str, split: str) -> Dataset:
 def _load_hf_dataset(
   name: str,
   config: str | None,
-  split: str,
+  split: str | None,
   cache_dir: str | None,
-) -> Dataset:
+) -> Dataset | DatasetDict:
   """Load a dataset from Hugging Face Hub or a GCS path.
 
-  If `name` is a GCS path (starts with 'gs://'), it loads a `datasets` object
-  from a directory saved with `save_to_disk`. Otherwise, it downloads and
-  returns a dataset from Hugging Face Hub.
-
   Args:
-    name: Name of the dataset on the hub, or a GCS path to a saved dataset.
+    name: Name of the dataset on the hub, or a path (local or GCS) to a saved dataset.
     config: Optional configuration name for datasets from the Hub.
-    split: Split to load.
+    split: Split to load. If None, all splits are loaded.
     cache_dir: Directory where the dataset cache should live.
 
   Returns:
-    The loaded ``Dataset`` instance for ``split``.
+    The loaded `datasets.Dataset` or `datasets.DatasetDict` object.
   """
-
   if name.startswith("gs://"):
     with model_utils.local_path_from_gcs(name, temp_dir=cache_dir) as local_path:
       data = load_from_disk(local_path)
   else:
     data = load_dataset(name, config, split=split, cache_dir=cache_dir)
   assert isinstance(data, Dataset | DatasetDict)
-  if isinstance(data, DatasetDict):
+  if isinstance(data, DatasetDict) and split is not None:
     data = data[split]
   return data
 
@@ -92,9 +62,9 @@ def load_hf_or_json_dataset(
   hf_dataset_name: str | None = None,
   hf_dataset_config_name: str | None = None,
   file_dataset_path: str | None = None,
-  split: str = "train",
+  split: str | None = "train",
   cache_dir: str | None = None,
-):
+) -> Dataset | DatasetDict:
   """Loads a dataset either from Hugging Face Hub or a local/remote JSONL file.
 
   This function abstracts the logic for loading datasets from two sources:
@@ -105,20 +75,24 @@ def load_hf_or_json_dataset(
     hf_dataset_name: Optional name of the HF dataset.
     hf_dataset_config_name: Optional configuration name for the HF dataset.
     file_dataset_path: Optional path to a JSONL file (local or remote).
-    split: Dataset split to load (default is "train").
+    split: Dataset split to load (default is "train"). If None, all splits are loaded.
     cache_dir: Optional directory to use for dataset caching (HF only).
 
   Returns:
-    A HuggingFace ``Dataset`` instance.
+    A HuggingFace ``Dataset`` or ``DatasetDict`` instance.
   """
   if hf_dataset_name:
     data = _load_hf_dataset(hf_dataset_name, hf_dataset_config_name, split, cache_dir)
   elif file_dataset_path:
+    if split is None:
+      raise ValueError("Loading all splits is not supported for a single JSONL file.")
     data = _load_json_dataset(file_dataset_path, split)
   else:
     raise ValueError("Either hf_dataset_name or file_dataset_path must be provided")
 
-  assert isinstance(data, Dataset), "Loaded dataset must be a Dataset instance."
+  assert isinstance(data, (Dataset, DatasetDict)), (
+    "Loaded dataset must be a Dataset or DatasetDict instance."
+  )
 
   return data
 
@@ -128,12 +102,12 @@ def make_train_dataset(
   hf_dataset_config_name: str | None = None,
   file_dataset_path: str | None = None,
   is_preprocessed: bool = False,
-  split: str = "train",
+  split: str | None = "train",
   cache_dir: str | None = None,
   *,
   tokenizer: PreTrainedTokenizerBase,
   block_size: int,
-) -> Dataset:
+) -> Dataset | DatasetDict:
   """Loads and tokenizes a dataset, then chunks it into fixed-size blocks for training.
 
   This function downloads a dataset from the Hugging Face Hub, tokenizes the `text`
@@ -148,23 +122,26 @@ def make_train_dataset(
     hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
     hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
     file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
-    is_preprocessed: If True, load a pre-tokenized dataset from disk.
-    split: Dataset split to load from HF. (e.g., "train", "validation").
+    is_preprocessed: If True, load a pre-tokenized dataset from disk. No tokenization is performed.
+    split: Dataset split to load from HF. (e.g., "train", "validation"). If None, all splits are loaded.
     cache_dir: Optional directory for HF dataset cache.
     tokenizer: A Hugging Face tokenizer used to tokenize the input text.
     block_size: The fixed length of each chunked training example.
 
   Returns:
-    A `Dataset` object with tokenized and block-wise grouped training examples.
+    A `Dataset` or `DatasetDict` object with tokenized and block-wise grouped training examples.
   """
   if is_preprocessed:
-    path = hf_dataset_name or file_dataset_path
-    if not path:
+    if not hf_dataset_name:
       raise ValueError(
-        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
+        "When `is_preprocessed` is True, the path to the preprocessed dataset must be provided via `hf_dataset_name`."
       )
-    data = _load_preprocessed_dataset(path, split, cache_dir)
-    if "input_ids" not in data.features or "labels" not in data.features:
+    data = _load_hf_dataset(
+      name=hf_dataset_name, config=None, split=split, cache_dir=cache_dir
+    )
+    # Check features on one of the splits if it's a DatasetDict
+    check_data = data[next(iter(data))] if isinstance(data, DatasetDict) else data
+    if "input_ids" not in check_data.features or "labels" not in check_data.features:
       raise ValueError(
         "Pre-processed dataset is missing 'input_ids' or 'labels' column, which are required for training."
       )
@@ -178,7 +155,12 @@ def make_train_dataset(
     cache_dir=cache_dir,
   )
 
-  column_names = list(data.features)
+  # Get column names from the first split if it's a DatasetDict
+  column_names = (
+    list(data[next(iter(data))].features)
+    if isinstance(data, DatasetDict)
+    else list(data.features)
+  )
   data = data.map(
     lambda samples: tokenizer(samples["text"]),
     batched=True,

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -90,9 +90,9 @@ def load_hf_or_json_dataset(
   else:
     raise ValueError("Either hf_dataset_name or file_dataset_path must be provided")
 
-  assert isinstance(data, (Dataset, DatasetDict)), (
-    "Loaded dataset must be a Dataset or DatasetDict instance."
-  )
+  assert isinstance(
+    data, Dataset | DatasetDict
+  ), "Loaded dataset must be a Dataset or DatasetDict instance."
 
   return data
 

--- a/torchprime/data/dataset.py
+++ b/torchprime/data/dataset.py
@@ -88,31 +88,35 @@ def _load_hf_dataset(
   return data
 
 
-def _load_raw_dataset(
-  path_or_name: str,
-  config_name: str | None = None,
+def load_hf_or_json_dataset(
+  hf_dataset_name: str | None = None,
+  hf_dataset_config_name: str | None = None,
+  file_dataset_path: str | None = None,
   split: str = "train",
   cache_dir: str | None = None,
 ):
-  """Loads a raw dataset from Hugging Face Hub, a GCS path, or a JSONL file.
+  """Loads a dataset either from Hugging Face Hub or a local/remote JSONL file.
 
   This function abstracts the logic for loading datasets from two sources:
-  1. Hugging Face Hub or a pre-saved GCS dataset directory.
-  2. A JSONL file (local or `gs://`-hosted).
+  1. Hugging Face Hub via `datasets.load_dataset`.
+  2. JSONL files (either local or `gs://`-hosted) using `fsspec`.
 
   Args:
-    path_or_name: Name of the HF dataset, or a path to a JSONL file or GCS directory.
-    config_name: Optional configuration name for the HF dataset.
+    hf_dataset_name: Optional name of the HF dataset.
+    hf_dataset_config_name: Optional configuration name for the HF dataset.
+    file_dataset_path: Optional path to a JSONL file (local or remote).
     split: Dataset split to load (default is "train").
     cache_dir: Optional directory to use for dataset caching (HF only).
 
   Returns:
     A HuggingFace ``Dataset`` instance.
   """
-  if path_or_name.endswith((".json", ".jsonl")):
-    data = _load_json_dataset(path_or_name, split)
+  if hf_dataset_name:
+    data = _load_hf_dataset(hf_dataset_name, hf_dataset_config_name, split, cache_dir)
+  elif file_dataset_path:
+    data = _load_json_dataset(file_dataset_path, split)
   else:
-    data = _load_hf_dataset(path_or_name, config_name, split, cache_dir)
+    raise ValueError("Either hf_dataset_name or file_dataset_path must be provided")
 
   assert isinstance(data, Dataset), "Loaded dataset must be a Dataset instance."
 
@@ -120,8 +124,9 @@ def _load_raw_dataset(
 
 
 def make_train_dataset(
-  dataset_path_or_name: str,
-  dataset_config_name: str | None = None,
+  hf_dataset_name: str | None = None,
+  hf_dataset_config_name: str | None = None,
+  file_dataset_path: str | None = None,
   is_preprocessed: bool = False,
   split: str = "train",
   cache_dir: str | None = None,
@@ -129,7 +134,7 @@ def make_train_dataset(
   tokenizer: PreTrainedTokenizerBase,
   block_size: int,
 ) -> Dataset:
-  """Load and prepare a dataset for causal language model training.
+  """Loads and tokenizes a dataset, then chunks it into fixed-size blocks for training.
 
   This function downloads a dataset from the Hugging Face Hub, tokenizes the `text`
   column using the provided tokenizer, and groups the resulting tokens into
@@ -137,12 +142,13 @@ def make_train_dataset(
   for efficient language modeling, especially on accelerators like TPUs.
 
   If `is_preprocessed` is True, the function loads a dataset directly from the
-  path specified in `dataset_path_or_name`, skipping tokenization.
+  path specified in `hf_dataset_name` or `file_dataset_path`, skipping tokenization.
 
   Args:
-    dataset_path_or_name: HF dataset name, or a path to a local/GCS dataset.
-    dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
-    is_preprocessed: If True, load a pre-tokenized dataset directly from the path.
+    hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
+    hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
+    file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
+    is_preprocessed: If True, load a pre-tokenized dataset from disk.
     split: Dataset split to load from HF. (e.g., "train", "validation").
     cache_dir: Optional directory for HF dataset cache.
     tokenizer: A Hugging Face tokenizer used to tokenize the input text.
@@ -152,16 +158,22 @@ def make_train_dataset(
     A `Dataset` object with tokenized and block-wise grouped training examples.
   """
   if is_preprocessed:
-    data = _load_preprocessed_dataset(dataset_path_or_name, split, cache_dir)
+    path = hf_dataset_name or file_dataset_path
+    if not path:
+      raise ValueError(
+        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
+      )
+    data = _load_preprocessed_dataset(path, split, cache_dir)
     if "input_ids" not in data.features or "labels" not in data.features:
       raise ValueError(
         "Pre-processed dataset is missing 'input_ids' or 'labels' column, which are required for training."
       )
     return data
 
-  data = _load_raw_dataset(
-    path_or_name=dataset_path_or_name,
-    config_name=dataset_config_name,
+  data = load_hf_or_json_dataset(
+    hf_dataset_name=hf_dataset_name,
+    hf_dataset_config_name=hf_dataset_config_name,
+    file_dataset_path=file_dataset_path,
     split=split,
     cache_dir=cache_dir,
   )

--- a/torchprime/data/sft_dataset.py
+++ b/torchprime/data/sft_dataset.py
@@ -7,7 +7,7 @@ from typing import Literal
 from datasets import Dataset
 from transformers.tokenization_utils import PreTrainedTokenizerBase
 
-from .dataset import _load_preprocessed_dataset, load_hf_or_json_dataset
+from .dataset import _load_hf_dataset, load_hf_or_json_dataset
 
 COMPUTE_OPTION = Literal["all", "completion", "assistant", "last_assistant"]
 FORMAT_OPTION = Literal["prompt_completion", "chat"]
@@ -307,12 +307,13 @@ def make_sft_dataset(
     Dataset of tokenized examples ready for model training.
   """
   if is_preprocessed:
-    path = hf_dataset_name or file_dataset_path
-    if not path:
+    if not hf_dataset_name:
       raise ValueError(
-        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
+        "A path must be provided via `hf_dataset_name` when `is_preprocessed` is True."
       )
-    data = _load_preprocessed_dataset(path, split, cache_dir)
+    data = _load_hf_dataset(
+      name=hf_dataset_name, config=None, split=split, cache_dir=cache_dir
+    )
     required_cols = ["input_ids", "labels", "attention_mask"]
     if not all(col in data.features for col in required_cols):
       raise ValueError(

--- a/torchprime/data/sft_dataset.py
+++ b/torchprime/data/sft_dataset.py
@@ -7,7 +7,7 @@ from typing import Literal
 from datasets import Dataset
 from transformers.tokenization_utils import PreTrainedTokenizerBase
 
-from .dataset import _load_preprocessed_dataset, _load_raw_dataset
+from .dataset import _load_preprocessed_dataset, load_hf_or_json_dataset
 
 COMPUTE_OPTION = Literal["all", "completion", "assistant", "last_assistant"]
 FORMAT_OPTION = Literal["prompt_completion", "chat"]
@@ -268,8 +268,9 @@ def _pad_and_maybe_pack_samples(
 
 
 def make_sft_dataset(
-  dataset_path_or_name: str,
-  dataset_config_name: str | None = None,
+  hf_dataset_name: str | None = None,
+  hf_dataset_config_name: str | None = None,
+  file_dataset_path: str | None = None,
   is_preprocessed: bool = False,
   split: str = "train",
   cache_dir: str | None = None,
@@ -288,9 +289,10 @@ def make_sft_dataset(
   The data can be in plain prompt/completion form or chat format.
 
   Args:
-    dataset_path_or_name: HF dataset name, or a path to a local/GCS dataset.
-    dataset_config_name: Optional HF dataset config name.
-    is_preprocessed: If True, load a pre-tokenized dataset directly from the path.
+    hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
+    hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
+    file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
+    is_preprocessed: If True, load a pre-tokenized dataset from disk.
     split: Dataset split to load from HF. (e.g., "train", "validation").
     cache_dir: Optional directory for HF dataset cache.
     format: ``"prompt_completion"`` or ``"chat"``.
@@ -305,7 +307,12 @@ def make_sft_dataset(
     Dataset of tokenized examples ready for model training.
   """
   if is_preprocessed:
-    data = _load_preprocessed_dataset(dataset_path_or_name, split, cache_dir)
+    path = hf_dataset_name or file_dataset_path
+    if not path:
+      raise ValueError(
+        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
+      )
+    data = _load_preprocessed_dataset(path, split, cache_dir)
     required_cols = ["input_ids", "labels", "attention_mask"]
     if not all(col in data.features for col in required_cols):
       raise ValueError(
@@ -314,9 +321,10 @@ def make_sft_dataset(
       )
     return data
 
-  data = _load_raw_dataset(
-    path_or_name=dataset_path_or_name,
-    config_name=dataset_config_name,
+  data = load_hf_or_json_dataset(
+    hf_dataset_name=hf_dataset_name,
+    hf_dataset_config_name=hf_dataset_config_name,
+    file_dataset_path=file_dataset_path,
     split=split,
     cache_dir=cache_dir,
   )

--- a/torchprime/data/sft_dataset.py
+++ b/torchprime/data/sft_dataset.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from datasets import Dataset, DatasetDict
+from datasets import Dataset
 from transformers.tokenization_utils import PreTrainedTokenizerBase
 
-from .dataset import _load_preprocessed_dataset, load_hf_or_json_dataset
+from .dataset import _load_preprocessed_dataset, _load_raw_dataset
 
 COMPUTE_OPTION = Literal["all", "completion", "assistant", "last_assistant"]
 FORMAT_OPTION = Literal["prompt_completion", "chat"]
@@ -268,9 +268,8 @@ def _pad_and_maybe_pack_samples(
 
 
 def make_sft_dataset(
-  hf_dataset_name: str | None = None,
-  hf_dataset_config_name: str | None = None,
-  file_dataset_path: str | None = None,
+  dataset_path_or_name: str,
+  dataset_config_name: str | None = None,
   is_preprocessed: bool = False,
   split: str = "train",
   cache_dir: str | None = None,
@@ -289,10 +288,9 @@ def make_sft_dataset(
   The data can be in plain prompt/completion form or chat format.
 
   Args:
-    hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
-    hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
-    file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
-    is_preprocessed: If True, load a pre-tokenized dataset from disk.
+    dataset_path_or_name: HF dataset name, or a path to a local/GCS dataset.
+    dataset_config_name: Optional HF dataset config name.
+    is_preprocessed: If True, load a pre-tokenized dataset directly from the path.
     split: Dataset split to load from HF. (e.g., "train", "validation").
     cache_dir: Optional directory for HF dataset cache.
     format: ``"prompt_completion"`` or ``"chat"``.
@@ -307,15 +305,7 @@ def make_sft_dataset(
     Dataset of tokenized examples ready for model training.
   """
   if is_preprocessed:
-    path = hf_dataset_name or file_dataset_path
-    if not path:
-      raise ValueError(
-        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
-      )
-    data = _load_preprocessed_dataset(path, cache_dir)
-    if isinstance(data, DatasetDict):
-      data = data[split]
-
+    data = _load_preprocessed_dataset(dataset_path_or_name, split, cache_dir)
     required_cols = ["input_ids", "labels", "attention_mask"]
     if not all(col in data.features for col in required_cols):
       raise ValueError(
@@ -324,10 +314,9 @@ def make_sft_dataset(
       )
     return data
 
-  data = load_hf_or_json_dataset(
-    hf_dataset_name=hf_dataset_name,
-    hf_dataset_config_name=hf_dataset_config_name,
-    file_dataset_path=file_dataset_path,
+  data = _load_raw_dataset(
+    path_or_name=dataset_path_or_name,
+    config_name=dataset_config_name,
     split=split,
     cache_dir=cache_dir,
   )

--- a/torchprime/data/sft_dataset.py
+++ b/torchprime/data/sft_dataset.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from datasets import Dataset
+from datasets import Dataset, DatasetDict
 from transformers.tokenization_utils import PreTrainedTokenizerBase
 
-from .dataset import load_hf_or_json_dataset
+from .dataset import _load_preprocessed_dataset, load_hf_or_json_dataset
 
 COMPUTE_OPTION = Literal["all", "completion", "assistant", "last_assistant"]
 FORMAT_OPTION = Literal["prompt_completion", "chat"]
@@ -271,6 +271,7 @@ def make_sft_dataset(
   hf_dataset_name: str | None = None,
   hf_dataset_config_name: str | None = None,
   file_dataset_path: str | None = None,
+  is_preprocessed: bool = False,
   split: str = "train",
   cache_dir: str | None = None,
   format: FORMAT_OPTION = "prompt_completion",
@@ -283,13 +284,15 @@ def make_sft_dataset(
 ) -> Dataset:
   """Create a dataset for supervised fine-tuning.
 
-  Either ``hf_dataset_name`` or ``file_dataset_path`` must be supplied to specify the data
-  source. The data can be in plain prompt/completion form or chat format.
+  If `is_preprocessed` is True, the function loads a dataset directly from the
+  path specified in `hf_dataset_name` or `file_dataset_path`, skipping tokenization.
+  The data can be in plain prompt/completion form or chat format.
 
   Args:
     hf_dataset_name: Optional Hugging Face dataset name. (e.g., "wikitext").
     hf_dataset_config_name: Optional HF dataset config name. (e.g., "wikitext-103-raw-v1").
     file_dataset_path: Optional path or ``gs://`` URI to a JSONL dataset.
+    is_preprocessed: If True, load a pre-tokenized dataset from disk.
     split: Dataset split to load from HF. (e.g., "train", "validation").
     cache_dir: Optional directory for HF dataset cache.
     format: ``"prompt_completion"`` or ``"chat"``.
@@ -303,6 +306,24 @@ def make_sft_dataset(
   Returns:
     Dataset of tokenized examples ready for model training.
   """
+  if is_preprocessed:
+    path = hf_dataset_name or file_dataset_path
+    if not path:
+      raise ValueError(
+        "A path must be provided via `hf_dataset_name` or `file_dataset_path` when `is_preprocessed` is True."
+      )
+    data = _load_preprocessed_dataset(path, cache_dir)
+    if isinstance(data, DatasetDict):
+      data = data[split]
+
+    required_cols = ["input_ids", "labels", "attention_mask"]
+    if not all(col in data.features for col in required_cols):
+      raise ValueError(
+        "Pre-processed SFT dataset is missing one of the required columns:"
+        f" {required_cols}. Available columns: {list(data.features.keys())}"
+      )
+    return data
+
   data = load_hf_or_json_dataset(
     hf_dataset_name=hf_dataset_name,
     hf_dataset_config_name=hf_dataset_config_name,

--- a/torchprime/data/sft_dataset.py
+++ b/torchprime/data/sft_dataset.py
@@ -284,8 +284,8 @@ def make_sft_dataset(
 ) -> Dataset:
   """Create a dataset for supervised fine-tuning.
 
-  If `is_preprocessed` is True, the function loads a dataset directly from the
-  path specified in `hf_dataset_name` or `file_dataset_path`, skipping tokenization.
+  If `is_preprocessed` is True, the function loads a dataset directly from the path
+  specified in `hf_dataset_name`, skipping tokenization.
   The data can be in plain prompt/completion form or chat format.
 
   Args:

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -25,7 +25,6 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 import torchprime.launcher.doctor
-from torchprime.launcher import save_hf_assets_to_gcs
 from torchprime.launcher.buildpush import buildpush
 from torchprime.launcher.util import run_docker
 
@@ -57,6 +56,8 @@ def save_hf_model_files_to_gcs(
   repo_id: str, gcs_path: str, file_type: str, temp_dir: str | None
 ):
   """Downloads model and tokenizer files from Hugging Face Hub and saves them to Google Cloud Storage."""
+  from torchprime.launcher import save_hf_assets_to_gcs
+
   print(f"Preparing to save '{file_type}' files from '{repo_id}' to '{gcs_path}'...")
   try:
     save_hf_assets_to_gcs.save_hf_model_files_to_gcs(
@@ -85,6 +86,8 @@ def save_hf_dataset(
   temp_dir: str | None,
 ):
   """Save Huggingface dataset to Google cloud storage."""
+  from torchprime.launcher import save_hf_assets_to_gcs
+
   print(f"Preparing to save dataset '{repo_id}' to '{gcs_path}'...")
   try:
     save_hf_assets_to_gcs.save_hf_dataset_to_gcs(

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -25,7 +25,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 import torchprime.launcher.doctor
-from torchprime.launcher import save_hf_tokenizer_and_model
+from torchprime.launcher import save_hf_assets_to_gcs
 from torchprime.launcher.buildpush import buildpush
 from torchprime.launcher.util import run_docker
 
@@ -59,7 +59,7 @@ def save_hf_model_files_to_gcs(
   """Downloads model and tokenizer files from Hugging Face Hub and saves them to Google Cloud Storage."""
   print(f"Preparing to save '{file_type}' files from '{repo_id}' to '{gcs_path}'...")
   try:
-    save_hf_tokenizer_and_model.save_hf_model_files_to_gcs(
+    save_hf_assets_to_gcs.save_hf_model_files_to_gcs(
       repo_id, gcs_path, file_type=file_type, temp_dir=temp_dir
     )
     print(f"  -> Successfully saved files to {gcs_path}")
@@ -72,6 +72,49 @@ def save_hf_model_files_to_gcs(
     )
   except Exception as e:
     print(f"\n❌ An unexpected error occurred for repository '{repo_id}': {e}")
+
+
+def save_hf_dataset(
+  repo_id: str,
+  gcs_path: str,
+  config_name: str | None,
+  split: str | None,
+  preprocess: bool,
+  tokenizer_repo_id: str | None,
+  block_size: int | None,
+  temp_dir: str | None,
+):
+  """Save Huggingface dataset to Google cloud storage."""
+  print(f"Preparing to save dataset '{repo_id}' to '{gcs_path}'...")
+  try:
+    save_hf_assets_to_gcs.save_hf_dataset_to_gcs(
+      repo_id=repo_id,
+      gcs_path=gcs_path,
+      config_name=config_name,
+      split=split,
+      preprocess=preprocess,
+      tokenizer_repo_id=tokenizer_repo_id,
+      block_size=block_size,
+      temp_dir=temp_dir,
+    )
+    print(f"  -> Successfully processed and saved dataset to {gcs_path}")
+  except ValueError as e:
+    print(f"\n❌ Configuration error: {e}")
+    print("Please check your command-line arguments and try again.")
+  except OSError as e:
+    if e.errno == 28:  # No space left on device
+      print(f"\n❌ Ran out of disk space: {e}")
+      print(
+        "The dataset is large and requires significant temporary storage for downloading and preprocessing."
+      )
+      print(
+        "Please specify a directory on a larger disk using the --temp-dir argument."
+      )
+      print("For example: --temp-dir /path/to/large/disk/temp")
+    else:
+      print(f"\n❌ An OS error occurred while saving dataset '{repo_id}': {e}")
+  except Exception as e:
+    print(f"\n❌ An unexpected error occurred while saving dataset '{repo_id}': {e}")
 
 
 def use(
@@ -678,6 +721,61 @@ def main():
     help="Path to a temporary directory with sufficient space. Defaults to system temp.",
   )
   parser_save_hf.set_defaults(func=save_hf_model_files_to_gcs)
+
+  # `save-hf-dataset` command
+  parser_save_dataset = subparsers.add_parser(
+    "save-hf-dataset",
+    help=save_hf_dataset.__doc__,
+    formatter_class=argparse.RawTextHelpFormatter,
+  )
+  parser_save_dataset.add_argument(
+    "--repo-id",
+    type=str,
+    required=True,
+    help="Hugging Face dataset repo ID (e.g., 'wikitext').",
+  )
+  parser_save_dataset.add_argument(
+    "--gcs-path",
+    type=str,
+    required=True,
+    help="Target GCS path for the dataset (e.g., 'gs://bucket/datasets/wikitext').",
+  )
+  parser_save_dataset.add_argument(
+    "--config-name",
+    type=str,
+    default=None,
+    help="Optional dataset configuration name (e.g., 'wikitext-103-raw-v1').",
+  )
+  parser_save_dataset.add_argument(
+    "--preprocess",
+    action="store_true",
+    help="If set, preprocess the dataset (tokenize and chunk). Otherwise, save the raw dataset.",
+  )
+  parser_save_dataset.add_argument(
+    "--split",
+    type=str,
+    default=None,
+    help="Dataset split to process (e.g., 'train'). Required if --preprocess is set. If not preprocessing, all splits are saved.",
+  )
+  parser_save_dataset.add_argument(
+    "--tokenizer-repo-id",
+    type=str,
+    default=None,
+    help="HF repo ID for the tokenizer. Required if --preprocess is set.",
+  )
+  parser_save_dataset.add_argument(
+    "--block-size",
+    type=int,
+    default=None,
+    help="Block size for chunking. Required if --preprocess is set.",
+  )
+  parser_save_dataset.add_argument(
+    "--temp-dir",
+    type=str,
+    default=None,
+    help="Path to a temporary directory with sufficient space. Defaults to system temp.",
+  )
+  parser_save_dataset.set_defaults(func=save_hf_dataset)
 
   # Parse arguments
   known_args, remaining_args = parser.parse_known_args()

--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -758,7 +758,7 @@ def main():
     "--split",
     type=str,
     default=None,
-    help="Dataset split to process (e.g., 'train'). Required if --preprocess is set. If not preprocessing, all splits are saved.",
+    help="Dataset split to process (e.g., 'train'). If not provided, all available splits will be processed/saved.",
   )
   parser_save_dataset.add_argument(
     "--tokenizer-repo-id",

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -6,7 +6,6 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from datasets import DatasetDict, load_dataset
 from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
@@ -105,6 +104,8 @@ def _save_raw_dataset(
   temp_dir: str | None,
 ):
   """Saves all raw dataset splits to GCS."""
+  from datasets import DatasetDict, load_dataset
+
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
     logger.info(f"Downloading raw dataset '{repo_id}' to '{tmpdir}'...")
     # load_dataset without a split downloads a DatasetDict with all splits

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -6,7 +6,11 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from datasets import DatasetDict, load_dataset
 from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
+
+from torchprime.data import dataset as torchprime_dataset
 
 logger = logging.getLogger(__name__)
 
@@ -92,3 +96,87 @@ def save_hf_model_files_to_gcs(
     logger.info(f"Files for '{repo_id}' downloaded locally to '{snapshot_path}'.")
 
     _upload_directory_to_gcs(Path(snapshot_path), gcs_path)
+
+
+def _save_raw_dataset(
+  repo_id: str,
+  gcs_path: str,
+  config_name: str | None,
+  temp_dir: str | None,
+):
+  """Saves all raw dataset splits to GCS."""
+  with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
+    logger.info(f"Downloading raw dataset '{repo_id}' to '{tmpdir}'...")
+    # load_dataset without a split downloads a DatasetDict with all splits
+    dataset = load_dataset(repo_id, name=config_name, cache_dir=tmpdir)
+    assert isinstance(dataset, DatasetDict)
+
+    save_path = Path(tmpdir) / "raw_dataset"
+    logger.info(f"Saving raw dataset to disk at '{save_path}'...")
+    dataset.save_to_disk(str(save_path))
+
+    logger.info(f"Uploading raw dataset from '{save_path}' to '{gcs_path}'...")
+    _upload_directory_to_gcs(save_path, gcs_path)
+
+
+def _save_preprocessed_dataset(
+  repo_id: str,
+  gcs_path: str,
+  config_name: str | None,
+  split: str,
+  tokenizer_repo_id: str,
+  block_size: int,
+  temp_dir: str | None,
+):
+  """Preprocesses a single split and saves it to GCS."""
+  with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
+    logger.info(f"Loading tokenizer '{tokenizer_repo_id}'...")
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_repo_id)
+
+    logger.info(
+      f"Loading and preprocessing split '{split}' from dataset '{repo_id}'..."
+    )
+    processed_dataset = torchprime_dataset.make_train_dataset(
+      hf_dataset_name=repo_id,
+      hf_dataset_config_name=config_name,
+      split=split,
+      tokenizer=tokenizer,
+      block_size=block_size,
+      cache_dir=tmpdir,
+    )
+
+    save_path = Path(tmpdir) / "preprocessed_dataset"
+    logger.info(f"Saving preprocessed dataset to disk at '{save_path}'...")
+    processed_dataset.save_to_disk(str(save_path))
+
+    logger.info(f"Uploading preprocessed dataset from '{save_path}' to '{gcs_path}'...")
+    _upload_directory_to_gcs(save_path, gcs_path)
+
+
+def save_hf_dataset_to_gcs(
+  repo_id: str,
+  gcs_path: str,
+  config_name: str | None = None,
+  split: str | None = None,
+  preprocess: bool = False,
+  tokenizer_repo_id: str | None = None,
+  block_size: int | None = None,
+  temp_dir: str | None = None,
+):
+  """Downloads a Hugging Face dataset, optionally preprocesses it, and uploads to GCS."""
+  if preprocess:
+    if not tokenizer_repo_id or not block_size or not split:
+      raise ValueError(
+        "For preprocessing, 'tokenizer_repo_id', 'block_size', and 'split' must be provided."
+      )
+    logger.info(f"Processing split '{split}' of dataset '{repo_id}'.")
+    _save_preprocessed_dataset(
+      repo_id, gcs_path, config_name, split, tokenizer_repo_id, block_size, temp_dir
+    )
+  else:
+    if split:
+      logger.warning(
+        "The --split argument is ignored when not preprocessing. All splits will be saved."
+      )
+    logger.info(f"Saving raw version of dataset '{repo_id}'.")
+    _save_raw_dataset(repo_id, gcs_path, config_name, temp_dir)

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from datasets import DatasetDict, load_dataset
 from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
@@ -104,8 +105,6 @@ def _save_raw_dataset(
   temp_dir: str | None,
 ):
   """Saves all raw dataset splits to GCS."""
-  from datasets import DatasetDict, load_dataset
-
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
     logger.info(f"Downloading raw dataset '{repo_id}' to '{tmpdir}'...")
     # load_dataset without a split downloads a DatasetDict with all splits

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -112,23 +112,14 @@ def _save_raw_dataset(
   are saved as a `DatasetDict`.
   """
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
-    if split:
-      logger.info(
-        f"Downloading raw dataset split '{split}' from '{repo_id}' to '{tmpdir}'..."
-      )
-      dataset = load_dataset(repo_id, name=config_name, split=split, cache_dir=tmpdir)
-    else:
-      logger.info(
-        f"Downloading all raw dataset splits from '{repo_id}' to '{tmpdir}'..."
-      )
-      dataset = load_dataset(repo_id, name=config_name, cache_dir=tmpdir)
+    dataset = load_dataset(repo_id, name=config_name, split=split, cache_dir=tmpdir)
+    if split is None:
       assert isinstance(dataset, DatasetDict)
 
     save_path = Path(tmpdir) / "raw_dataset"
     logger.info(f"Saving raw dataset to disk at '{save_path}'...")
     dataset.save_to_disk(str(save_path))
 
-    logger.info(f"Uploading raw dataset from '{save_path}' to '{gcs_path}'...")
     _upload_directory_to_gcs(save_path, gcs_path)
 
 
@@ -153,12 +144,6 @@ def _save_preprocessed_dataset(
     ) as tokenizer_path:
       tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
 
-    log_message = (
-      f"Loading and preprocessing split '{split}' from dataset '{repo_id}'..."
-      if split
-      else f"Loading and preprocessing all splits from dataset '{repo_id}'..."
-    )
-    logger.info(log_message)
     processed_dataset = torchprime_dataset.make_train_dataset(
       hf_dataset_name=repo_id,
       hf_dataset_config_name=config_name,
@@ -172,7 +157,6 @@ def _save_preprocessed_dataset(
     logger.info(f"Saving preprocessed dataset to disk at '{save_path}'...")
     processed_dataset.save_to_disk(str(save_path))
 
-    logger.info(f"Uploading preprocessed dataset from '{save_path}' to '{gcs_path}'...")
     _upload_directory_to_gcs(save_path, gcs_path)
 
 
@@ -187,21 +171,17 @@ def save_hf_dataset_to_gcs(
   temp_dir: str | None = None,
 ):
   """Downloads a Hugging Face dataset, optionally preprocesses it, and uploads to GCS."""
+  action = "Processing" if preprocess else "Saving raw"
+  split_info = f"split '{split}'" if split else "all splits"
+  logger.info(f"{action} {split_info} of dataset '{repo_id}'.")
+
   if preprocess:
     if not tokenizer_repo_id or not block_size:
       raise ValueError(
         "For preprocessing, 'tokenizer_repo_id' and 'block_size' must be provided."
       )
-    if split:
-      logger.info(f"Processing split '{split}' of dataset '{repo_id}'.")
-    else:
-      logger.info(f"Processing all splits of dataset '{repo_id}'.")
     _save_preprocessed_dataset(
       repo_id, gcs_path, config_name, split, tokenizer_repo_id, block_size, temp_dir
     )
   else:
-    if split:
-      logger.info(f"Saving raw split '{split}' of dataset '{repo_id}'.")
-    else:
-      logger.info(f"Saving all raw splits of dataset '{repo_id}'.")
     _save_raw_dataset(repo_id, gcs_path, config_name, split, temp_dir)

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -112,10 +112,14 @@ def _save_raw_dataset(
   """
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
     if split:
-      logger.info(f"Downloading raw dataset split '{split}' from '{repo_id}' to '{tmpdir}'...")
+      logger.info(
+        f"Downloading raw dataset split '{split}' from '{repo_id}' to '{tmpdir}'..."
+      )
       dataset = load_dataset(repo_id, name=config_name, split=split, cache_dir=tmpdir)
     else:
-      logger.info(f"Downloading all raw dataset splits from '{repo_id}' to '{tmpdir}'...")
+      logger.info(
+        f"Downloading all raw dataset splits from '{repo_id}' to '{tmpdir}'..."
+      )
       dataset = load_dataset(repo_id, name=config_name, cache_dir=tmpdir)
       assert isinstance(dataset, DatasetDict)
 

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -6,11 +6,12 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from datasets import DatasetDict, get_dataset_split_names, load_dataset
+from datasets import DatasetDict, load_dataset
 from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
 from torchprime.data import dataset as torchprime_dataset
+from torchprime.torch_xla_models.model import model_utils
 
 logger = logging.getLogger(__name__)
 
@@ -147,36 +148,25 @@ def _save_preprocessed_dataset(
   """
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
     logger.info(f"Loading tokenizer '{tokenizer_repo_id}'...")
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_repo_id)
+    with model_utils.local_path_from_gcs(
+      tokenizer_repo_id, temp_dir=tmpdir
+    ) as tokenizer_path:
+      tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
 
-    if split:
-      logger.info(
-        f"Loading and preprocessing split '{split}' from dataset '{repo_id}'..."
-      )
-      processed_dataset = torchprime_dataset.make_train_dataset(
-        dataset_path_or_name=repo_id,
-        dataset_config_name=config_name,
-        split=split,
-        tokenizer=tokenizer,
-        block_size=block_size,
-        cache_dir=tmpdir,
-      )
-    else:
-      logger.info(f"Loading and preprocessing all splits from dataset '{repo_id}'...")
-      split_names = get_dataset_split_names(repo_id, name=config_name)
-      processed_splits = {}
-      for split_name in split_names:
-        logger.info(f"  - Processing split: {split_name}")
-        processed_split = torchprime_dataset.make_train_dataset(
-          dataset_path_or_name=repo_id,
-          dataset_config_name=config_name,
-          split=split_name,
-          tokenizer=tokenizer,
-          block_size=block_size,
-          cache_dir=tmpdir,
-        )
-        processed_splits[split_name] = processed_split
-      processed_dataset = DatasetDict(processed_splits)
+    log_message = (
+      f"Loading and preprocessing split '{split}' from dataset '{repo_id}'..."
+      if split
+      else f"Loading and preprocessing all splits from dataset '{repo_id}'..."
+    )
+    logger.info(log_message)
+    processed_dataset = torchprime_dataset.make_train_dataset(
+      hf_dataset_name=repo_id,
+      hf_dataset_config_name=config_name,
+      split=split,
+      tokenizer=tokenizer,
+      block_size=block_size,
+      cache_dir=tmpdir,
+    )
 
     save_path = Path(tmpdir) / "preprocessed_dataset"
     logger.info(f"Saving preprocessed dataset to disk at '{save_path}'...")

--- a/torchprime/launcher/save_hf_assets_to_gcs.py
+++ b/torchprime/launcher/save_hf_assets_to_gcs.py
@@ -6,7 +6,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from datasets import DatasetDict, load_dataset
+from datasets import DatasetDict, get_dataset_split_names, load_dataset
 from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
@@ -102,14 +102,22 @@ def _save_raw_dataset(
   repo_id: str,
   gcs_path: str,
   config_name: str | None,
+  split: str | None,
   temp_dir: str | None,
 ):
-  """Saves all raw dataset splits to GCS."""
+  """Saves raw dataset splits to GCS.
+
+  If a split is specified, only that split is saved. Otherwise, all splits
+  are saved as a `DatasetDict`.
+  """
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
-    logger.info(f"Downloading raw dataset '{repo_id}' to '{tmpdir}'...")
-    # load_dataset without a split downloads a DatasetDict with all splits
-    dataset = load_dataset(repo_id, name=config_name, cache_dir=tmpdir)
-    assert isinstance(dataset, DatasetDict)
+    if split:
+      logger.info(f"Downloading raw dataset split '{split}' from '{repo_id}' to '{tmpdir}'...")
+      dataset = load_dataset(repo_id, name=config_name, split=split, cache_dir=tmpdir)
+    else:
+      logger.info(f"Downloading all raw dataset splits from '{repo_id}' to '{tmpdir}'...")
+      dataset = load_dataset(repo_id, name=config_name, cache_dir=tmpdir)
+      assert isinstance(dataset, DatasetDict)
 
     save_path = Path(tmpdir) / "raw_dataset"
     logger.info(f"Saving raw dataset to disk at '{save_path}'...")
@@ -123,27 +131,48 @@ def _save_preprocessed_dataset(
   repo_id: str,
   gcs_path: str,
   config_name: str | None,
-  split: str,
+  split: str | None,
   tokenizer_repo_id: str,
   block_size: int,
   temp_dir: str | None,
 ):
-  """Preprocesses a single split and saves it to GCS."""
+  """Preprocesses dataset splits and saves them to GCS.
+
+  If a split is specified, only that split is preprocessed and saved.
+  Otherwise, all available splits are preprocessed and saved as a `DatasetDict`.
+  """
   with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdir:
     logger.info(f"Loading tokenizer '{tokenizer_repo_id}'...")
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_repo_id)
 
-    logger.info(
-      f"Loading and preprocessing split '{split}' from dataset '{repo_id}'..."
-    )
-    processed_dataset = torchprime_dataset.make_train_dataset(
-      hf_dataset_name=repo_id,
-      hf_dataset_config_name=config_name,
-      split=split,
-      tokenizer=tokenizer,
-      block_size=block_size,
-      cache_dir=tmpdir,
-    )
+    if split:
+      logger.info(
+        f"Loading and preprocessing split '{split}' from dataset '{repo_id}'..."
+      )
+      processed_dataset = torchprime_dataset.make_train_dataset(
+        dataset_path_or_name=repo_id,
+        dataset_config_name=config_name,
+        split=split,
+        tokenizer=tokenizer,
+        block_size=block_size,
+        cache_dir=tmpdir,
+      )
+    else:
+      logger.info(f"Loading and preprocessing all splits from dataset '{repo_id}'...")
+      split_names = get_dataset_split_names(repo_id, name=config_name)
+      processed_splits = {}
+      for split_name in split_names:
+        logger.info(f"  - Processing split: {split_name}")
+        processed_split = torchprime_dataset.make_train_dataset(
+          dataset_path_or_name=repo_id,
+          dataset_config_name=config_name,
+          split=split_name,
+          tokenizer=tokenizer,
+          block_size=block_size,
+          cache_dir=tmpdir,
+        )
+        processed_splits[split_name] = processed_split
+      processed_dataset = DatasetDict(processed_splits)
 
     save_path = Path(tmpdir) / "preprocessed_dataset"
     logger.info(f"Saving preprocessed dataset to disk at '{save_path}'...")
@@ -165,18 +194,20 @@ def save_hf_dataset_to_gcs(
 ):
   """Downloads a Hugging Face dataset, optionally preprocesses it, and uploads to GCS."""
   if preprocess:
-    if not tokenizer_repo_id or not block_size or not split:
+    if not tokenizer_repo_id or not block_size:
       raise ValueError(
-        "For preprocessing, 'tokenizer_repo_id', 'block_size', and 'split' must be provided."
+        "For preprocessing, 'tokenizer_repo_id' and 'block_size' must be provided."
       )
-    logger.info(f"Processing split '{split}' of dataset '{repo_id}'.")
+    if split:
+      logger.info(f"Processing split '{split}' of dataset '{repo_id}'.")
+    else:
+      logger.info(f"Processing all splits of dataset '{repo_id}'.")
     _save_preprocessed_dataset(
       repo_id, gcs_path, config_name, split, tokenizer_repo_id, block_size, temp_dir
     )
   else:
     if split:
-      logger.warning(
-        "The --split argument is ignored when not preprocessing. All splits will be saved."
-      )
-    logger.info(f"Saving raw version of dataset '{repo_id}'.")
-    _save_raw_dataset(repo_id, gcs_path, config_name, temp_dir)
+      logger.info(f"Saving raw split '{split}' of dataset '{repo_id}'.")
+    else:
+      logger.info(f"Saving all raw splits of dataset '{repo_id}'.")
+    _save_raw_dataset(repo_id, gcs_path, config_name, split, temp_dir)

--- a/torchprime/torch_xla_models/configs/default.yaml
+++ b/torchprime/torch_xla_models/configs/default.yaml
@@ -31,6 +31,11 @@ output_dir: outputs
 # If unspecified, defaults to the current date and time.
 run_name: null
 
+dataset:
+  # If true, the dataset specified by `hf_dataset_name` or `file_dataset_path`
+  # is assumed to be pre-tokenized and saved to disk.
+  is_preprocessed: false
+
 # The virtual device mesh shape to use within a TPU slice. This is also called
 # the "ICI mesh", since devices within a slice enjoy a faster network called
 # "Inter-Chip Interconnect".


### PR DESCRIPTION
- created tp command to save raw/processed dataset in gcs
- enabled make_train_dataset to load preprocessed dataset from gcs bucket

https://github.com/AI-Hypercomputer/torchprime/issues/115
https://github.com/AI-Hypercomputer/torchprime/issues/262

Saving preprocessed dataset:
```
 tp save-hf-dataset     --repo-id wikitext     --config-name wikitext-103-raw-v1     --gcs-path gs://bucketname/datasets/wikitext-preprocessed     --preprocess     --split train     --tokenizer-repo-id meta-llama/Meta-Llama-3-8B     --block-size 1024     --temp-dir /tmp
```

Tested with wikitext data on llama-3-8B