### PR TITLE
Remove _google_com from workload name to prevent having long name

### DIFF
--- a/torchprime/launcher/cli.py
+++ b/torchprime/launcher/cli.py
@@ -306,9 +306,7 @@ def run(
   if workload_name is None:
     user = os.environ.get("USER").replace("_google_com", "")
     datetime_str = datetime.now().strftime("%Y%m%d-%H%M%S")
-    workload_name = (
-      f"{user}-xpk-{config.tpu_type}-{config.num_slices}-{datetime_str}"
-    )
+    workload_name = f"{user}-xpk-{config.tpu_type}-{config.num_slices}-{datetime_str}"
 
   if not (
     re.match(r"[a-z]([-a-z0-9]*[a-z0-9])?", workload_name) and len(workload_name) < 40


### PR DESCRIPTION
When I run `tp run` without `--name`, I always get an error because my workload name is too long. 

Getting rid of "_google_com" from default workload name would be useful to have shorter default workload name.