### PR TITLE
Fix test_run_model from hanging when running on TPU

### DIFF
--- a/torchprime/launcher/test_run_model.py
+++ b/torchprime/launcher/test_run_model.py
@@ -12,22 +12,32 @@ class SimpleModel(torch.nn.Module):
     return (torch.randn(batch_size, 10),), {}
 
 
-def test_run_model():
+def test_run_model_xla():
   m = SimpleModel()
   times = run_model.run_model_xla(m, 5, 3)
   assert len(times) == 3
+
+
+def test_run_model_torchax():
+  m = SimpleModel()
   times = run_model.run_model_torchax(m, 5, 3, eager=True)
   assert len(times) == 3
   times = run_model.run_model_torchax(m, 5, 3, eager=False)
   assert len(times) == 3
 
 
-def test_run_model_transact():
+def test_run_model_transact_xla():
   model_id = "pinterest/transformer_user_action"
   model_factory = models.registry.get(model_id)
   model = model_factory()
   times = run_model.run_model_xla(model, 1, 3)
   assert len(times) == 3
+
+
+def test_run_model_transact_torchax():
+  model_id = "pinterest/transformer_user_action"
+  model_factory = models.registry.get(model_id)
+  model = model_factory()
   times = run_model.run_model_torchax(model, 1, 3, eager=True)
   assert len(times) == 3
   times = run_model.run_model_torchax(model, 1, 3, eager=False)


### PR DESCRIPTION
When running test_run_model on TPU, it was hanging indefinitely. I realized that the hanging was occuring when testing the torchax part and when I divide them to two separate test, hanging stopped.

I am not exactly sure why this is happening but my best guess is some conflict between initializing backend for TPU. If anyone knows better explanation, please let me know.


Environment:
- TPU VM: v4-8
- Python 3.11