### PR TITLE
Fix TPU unit test hanging

### DIFF
--- a/torchprime/launcher/run_model.py
+++ b/torchprime/launcher/run_model.py
@@ -1,14 +1,15 @@
 import time
 
-import jax
 import torch
-import torchax as tx
-import torchax.interop
 from torch.utils import _pytree as pytree
 from torch_xla.core import xla_model as xm
 
 
 def run_model_torchax(model, batch_size, number_of_runs, eager):
+  import jax
+  import torchax as tx
+  import torchax.interop
+
   torchax.enable_globally()
   model = model.to("jax")
 


### PR DESCRIPTION
When running unit test on TPU, some of there were hanging: https://github.com/AI-Hypercomputer/torchprime/issues/375

Seems like the hanging for some test only happens when `test_run_model.py` was ran before (could be some deadlock happening to access libtpu. It was fixed by importing torchax at function level.